### PR TITLE
Fix agent references and collection imports

### DIFF
--- a/Assets/Scripts/Agents/AgentSystem.cs
+++ b/Assets/Scripts/Agents/AgentSystem.cs
@@ -1,6 +1,7 @@
 // Scripts/Agents/AgentSystem.cs
 
 using System.Collections.Generic;
+using Waiter = TavernSim.Agents.Waiter;
 public sealed class AgentSystem : ISimSystem {
     readonly List<Customer> _customers = new();
     readonly List<Waiter> _waiters = new();

--- a/Assets/Scripts/Agents/Waiter.cs
+++ b/Assets/Scripts/Agents/Waiter.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace TavernSim.Agents
 {
-    public sealed class Waiter
+    public sealed class Waiter : MonoBehaviour
     {
         // Expandir depois (FSM etc.)
         public void Tick(float dt) { }

--- a/Assets/Scripts/Save/SaveModel.cs
+++ b/Assets/Scripts/Save/SaveModel.cs
@@ -1,4 +1,6 @@
 // Scripts/Save/SaveModel.cs
+using System.Collections.Generic;
+
 [System.Serializable]
 public sealed class SaveModel {
     public int version = 1;

--- a/Assets/Scripts/Simulation/OrderSystem.cs
+++ b/Assets/Scripts/Simulation/OrderSystem.cs
@@ -1,4 +1,6 @@
 // Scripts/Simulation/OrderSystem.cs
+using System.Collections.Generic;
+
 public sealed class OrderSystem : ISimSystem {
     readonly Queue<Order> _pending = new();
     readonly List<Order> _inPrep = new();


### PR DESCRIPTION
## Summary
- add missing System.Collections.Generic imports for save and order systems
- resolve the waiter reference in the lightweight agent system stub
- derive the Waiter component from MonoBehaviour to support Unity usage

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68cb4b6edcd48333b771877f35f81a20