### PR TITLE
Load TavernCatalog from Resources by default

### DIFF
--- a/Assets/Bootstrap/DevBootstrap.cs
+++ b/Assets/Bootstrap/DevBootstrap.cs
@@ -46,7 +46,7 @@ namespace TavernSim.Bootstrap
         {
             if (catalog == null)
             {
-                catalog = Resources.Load<Catalog>("DemoCatalog");
+                catalog = Resources.Load<Catalog>("TavernCatalog");
             }
 
             SetupScene();

--- a/Assets/Resources.meta
+++ b/Assets/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c9427b9ed6504833999bf5322447b5ba
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/TavernCatalog.asset
+++ b/Assets/Resources/TavernCatalog.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 60cc01f15063d1143b1daed2edca3d58, type: 3}
+  m_Name: TavernCatalog
+  m_EditorClassIdentifier: 
+  items:
+  - {fileID: 11400000, guid: d30098e98e8c44f7a9b31a6930d0d529, type: 2}
+  - {fileID: 11400000, guid: 5c04bb5c528a41beb0213086b6285b37, type: 2}
+  - {fileID: 11400000, guid: 23e9f780efba4a92905462e43754290d, type: 2}
+  - {fileID: 11400000, guid: 756532a8a2374de8be8c3b0fc4b3ebea, type: 2}
+  - {fileID: 11400000, guid: b706028e4ded407cafbf0334ca327f5d, type: 2}
+  - {fileID: 11400000, guid: 606c5cfca78741f9a6193f592bc18867, type: 2}
+  - {fileID: 11400000, guid: a6652589ada3482fa9d5db4573ae4dbc, type: 2}
+  - {fileID: 11400000, guid: 05055d29128f44e69f41f6283fc7dfb7, type: 2}
+  recipes:
+  - {fileID: 11400000, guid: 3681f56bc3144b0dbbbd7f9a14f19805, type: 2}
+  - {fileID: 11400000, guid: 465c443e6463449fb0bad650f0d2d116, type: 2}
+  - {fileID: 11400000, guid: 34e5ecf33e104564832be25397a16eeb, type: 2}

--- a/Assets/Resources/TavernCatalog.asset.meta
+++ b/Assets/Resources/TavernCatalog.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 72cbbf18508245ef95acd99b18a5afcc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/ScriptableObjects/Items/BarleyGrain.asset
+++ b/Assets/ScriptableObjects/Items/BarleyGrain.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ccbaa0a9a24564e498795b0c53a19970, type: 3}
+  m_Name: BarleyGrain
+  m_EditorClassIdentifier: 
+  id: item.barley_grain
+  displayName: Barley Grain
+  unitCost: 1
+  sellPrice: 1

--- a/Assets/ScriptableObjects/Items/BarleyGrain.asset.meta
+++ b/Assets/ScriptableObjects/Items/BarleyGrain.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 756532a8a2374de8be8c3b0fc4b3ebea
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/ScriptableObjects/Items/FreshBread.asset
+++ b/Assets/ScriptableObjects/Items/FreshBread.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ccbaa0a9a24564e498795b0c53a19970, type: 3}
+  m_Name: FreshBread
+  m_EditorClassIdentifier: 
+  id: item.fresh_bread
+  displayName: Fresh Bread
+  unitCost: 3
+  sellPrice: 6

--- a/Assets/ScriptableObjects/Items/FreshBread.asset.meta
+++ b/Assets/ScriptableObjects/Items/FreshBread.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 606c5cfca78741f9a6193f592bc18867
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/ScriptableObjects/Items/FreshWater.asset
+++ b/Assets/ScriptableObjects/Items/FreshWater.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ccbaa0a9a24564e498795b0c53a19970, type: 3}
+  m_Name: FreshWater
+  m_EditorClassIdentifier: 
+  id: item.fresh_water
+  displayName: Fresh Water
+  unitCost: 0
+  sellPrice: 0

--- a/Assets/ScriptableObjects/Items/FreshWater.asset.meta
+++ b/Assets/ScriptableObjects/Items/FreshWater.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b706028e4ded407cafbf0334ca327f5d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/ScriptableObjects/Items/GameMeat.asset
+++ b/Assets/ScriptableObjects/Items/GameMeat.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ccbaa0a9a24564e498795b0c53a19970, type: 3}
+  m_Name: GameMeat
+  m_EditorClassIdentifier: 
+  id: item.game_meat
+  displayName: Game Meat
+  unitCost: 3
+  sellPrice: 4

--- a/Assets/ScriptableObjects/Items/GameMeat.asset.meta
+++ b/Assets/ScriptableObjects/Items/GameMeat.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5c04bb5c528a41beb0213086b6285b37
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/ScriptableObjects/Items/HeartyStew.asset
+++ b/Assets/ScriptableObjects/Items/HeartyStew.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ccbaa0a9a24564e498795b0c53a19970, type: 3}
+  m_Name: HeartyStew
+  m_EditorClassIdentifier: 
+  id: item.hearty_stew
+  displayName: Hearty Stew
+  unitCost: 5
+  sellPrice: 10

--- a/Assets/ScriptableObjects/Items/HeartyStew.asset.meta
+++ b/Assets/ScriptableObjects/Items/HeartyStew.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 05055d29128f44e69f41f6283fc7dfb7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/ScriptableObjects/Items/HouseAle.asset
+++ b/Assets/ScriptableObjects/Items/HouseAle.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ccbaa0a9a24564e498795b0c53a19970, type: 3}
+  m_Name: HouseAle
+  m_EditorClassIdentifier: 
+  id: item.house_ale
+  displayName: House Ale
+  unitCost: 2
+  sellPrice: 5

--- a/Assets/ScriptableObjects/Items/HouseAle.asset.meta
+++ b/Assets/ScriptableObjects/Items/HouseAle.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a6652589ada3482fa9d5db4573ae4dbc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/ScriptableObjects/Items/RootVegetables.asset
+++ b/Assets/ScriptableObjects/Items/RootVegetables.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ccbaa0a9a24564e498795b0c53a19970, type: 3}
+  m_Name: RootVegetables
+  m_EditorClassIdentifier: 
+  id: item.root_vegetables
+  displayName: Root Vegetables
+  unitCost: 2
+  sellPrice: 3

--- a/Assets/ScriptableObjects/Items/RootVegetables.asset.meta
+++ b/Assets/ScriptableObjects/Items/RootVegetables.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 23e9f780efba4a92905462e43754290d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/ScriptableObjects/Items/YeastedDough.asset
+++ b/Assets/ScriptableObjects/Items/YeastedDough.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ccbaa0a9a24564e498795b0c53a19970, type: 3}
+  m_Name: YeastedDough
+  m_EditorClassIdentifier: 
+  id: item.yeasted_dough
+  displayName: Yeasted Dough
+  unitCost: 2
+  sellPrice: 1

--- a/Assets/ScriptableObjects/Items/YeastedDough.asset.meta
+++ b/Assets/ScriptableObjects/Items/YeastedDough.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d30098e98e8c44f7a9b31a6930d0d529
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/ScriptableObjects/Recipes/BakeBread.asset
+++ b/Assets/ScriptableObjects/Recipes/BakeBread.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ea920ff61c5e36249b4b0bf99309c61a, type: 3}
+  m_Name: BakeBread
+  m_EditorClassIdentifier: 
+  id: recipe.bake_bread
+  displayName: Bake Bread
+  ingredients:
+  - {fileID: 11400000, guid: d30098e98e8c44f7a9b31a6930d0d529, type: 2}
+  prepTime: 4
+  outputItem: {fileID: 11400000, guid: 606c5cfca78741f9a6193f592bc18867, type: 2}

--- a/Assets/ScriptableObjects/Recipes/BakeBread.asset.meta
+++ b/Assets/ScriptableObjects/Recipes/BakeBread.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3681f56bc3144b0dbbbd7f9a14f19805
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/ScriptableObjects/Recipes/BrewHouseAle.asset
+++ b/Assets/ScriptableObjects/Recipes/BrewHouseAle.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ea920ff61c5e36249b4b0bf99309c61a, type: 3}
+  m_Name: BrewHouseAle
+  m_EditorClassIdentifier: 
+  id: recipe.house_ale
+  displayName: Brew House Ale
+  ingredients:
+  - {fileID: 11400000, guid: 756532a8a2374de8be8c3b0fc4b3ebea, type: 2}
+  - {fileID: 11400000, guid: b706028e4ded407cafbf0334ca327f5d, type: 2}
+  prepTime: 6
+  outputItem: {fileID: 11400000, guid: a6652589ada3482fa9d5db4573ae4dbc, type: 2}

--- a/Assets/ScriptableObjects/Recipes/BrewHouseAle.asset.meta
+++ b/Assets/ScriptableObjects/Recipes/BrewHouseAle.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 465c443e6463449fb0bad650f0d2d116
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/ScriptableObjects/Recipes/CookHeartyStew.asset
+++ b/Assets/ScriptableObjects/Recipes/CookHeartyStew.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ea920ff61c5e36249b4b0bf99309c61a, type: 3}
+  m_Name: CookHeartyStew
+  m_EditorClassIdentifier: 
+  id: recipe.hearty_stew
+  displayName: Cook Hearty Stew
+  ingredients:
+  - {fileID: 11400000, guid: 5c04bb5c528a41beb0213086b6285b37, type: 2}
+  - {fileID: 11400000, guid: 23e9f780efba4a92905462e43754290d, type: 2}
+  - {fileID: 11400000, guid: b706028e4ded407cafbf0334ca327f5d, type: 2}
+  prepTime: 8
+  outputItem: {fileID: 11400000, guid: 05055d29128f44e69f41f6283fc7dfb7, type: 2}

--- a/Assets/ScriptableObjects/Recipes/CookHeartyStew.asset.meta
+++ b/Assets/ScriptableObjects/Recipes/CookHeartyStew.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 34e5ecf33e104564832be25397a16eeb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- move the TavernCatalog asset into Assets/Resources so DevBootstrap can load it automatically
- update DevBootstrap's fallback lookup to request the TavernCatalog asset when no catalog is assigned
- add the Resources folder metadata so Unity tracks the new folder

## Testing
- not run (asset / configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68ceba3b657c83339fac9077b18d2655