### PR TITLE
Fix input handling to support new Input System

### DIFF
--- a/Assets/Building/GridPlacer.cs
+++ b/Assets/Building/GridPlacer.cs
@@ -1,5 +1,8 @@
 using UnityEngine;
 using TavernSim.Simulation.Systems;
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+using UnityEngine.InputSystem;
+#endif
 
 namespace TavernSim.Building
 {
@@ -25,22 +28,43 @@ namespace TavernSim.Building
                 return;
             }
 
-            if (Input.GetMouseButtonDown(0))
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+            var mouse = Mouse.current;
+            if (mouse == null || !mouse.leftButton.wasPressedThisFrame)
             {
-                var ray = Camera.main != null ? Camera.main.ScreenPointToRay(Input.mousePosition) : default;
-                if (Physics.Raycast(ray, out var hit, 100f))
-                {
-                    var position = hit.point;
-                    position.x = Mathf.Round(position.x / gridSize) * gridSize;
-                    position.z = Mathf.Round(position.z / gridSize) * gridSize;
-                    position.y = 0f;
+                return;
+            }
 
-                    if (_economySystem.TrySpend(propCost))
-                    {
-                        var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                        cube.transform.position = position;
-                        cube.transform.localScale = new Vector3(1f, 0.5f, 1f);
-                    }
+            var pointerPosition = mouse.position.ReadValue();
+            var screenPoint = new Vector3(pointerPosition.x, pointerPosition.y, 0f);
+#else
+            if (!Input.GetMouseButtonDown(0))
+            {
+                return;
+            }
+
+            var screenPoint = Input.mousePosition;
+#endif
+
+            var mainCamera = Camera.main;
+            if (mainCamera == null)
+            {
+                return;
+            }
+
+            var ray = mainCamera.ScreenPointToRay(screenPoint);
+            if (Physics.Raycast(ray, out var hit, 100f))
+            {
+                var position = hit.point;
+                position.x = Mathf.Round(position.x / gridSize) * gridSize;
+                position.z = Mathf.Round(position.z / gridSize) * gridSize;
+                position.y = 0f;
+
+                if (_economySystem.TrySpend(propCost))
+                {
+                    var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+                    cube.transform.position = position;
+                    cube.transform.localScale = new Vector3(1f, 0.5f, 1f);
                 }
             }
         }

--- a/Assets/UI/HUDController.cs
+++ b/Assets/UI/HUDController.cs
@@ -3,6 +3,9 @@ using UnityEngine;
 using UnityEngine.UIElements;
 using TavernSim.Save;
 using TavernSim.Simulation.Systems;
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+using UnityEngine.InputSystem;
+#endif
 
 namespace TavernSim.UI
 {
@@ -70,6 +73,23 @@ namespace TavernSim.UI
                 return;
             }
 
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+            var keyboard = Keyboard.current;
+            if (keyboard == null)
+            {
+                return;
+            }
+
+            if (keyboard.f5Key.wasPressedThisFrame)
+            {
+                SaveGame();
+            }
+
+            if (keyboard.f9Key.wasPressedThisFrame)
+            {
+                LoadGame();
+            }
+#else
             if (Input.GetKeyDown(KeyCode.F5))
             {
                 SaveGame();
@@ -79,6 +99,7 @@ namespace TavernSim.UI
             {
                 LoadGame();
             }
+#endif
         }
 
         public void SetCustomers(int count)

--- a/Assets/UI/TimeControls.cs
+++ b/Assets/UI/TimeControls.cs
@@ -1,5 +1,8 @@
 using UnityEngine;
 using UnityEngine.UIElements;
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+using UnityEngine.InputSystem;
+#endif
 
 namespace TavernSim.UI
 {
@@ -25,10 +28,18 @@ namespace TavernSim.UI
 
         private void Update()
         {
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+            var keyboard = Keyboard.current;
+            if (keyboard != null && keyboard.spaceKey.wasPressedThisFrame)
+            {
+                TogglePause();
+            }
+#else
             if (Input.GetKeyDown(KeyCode.Space))
             {
                 TogglePause();
             }
+#endif
         }
 
         private void Hook()


### PR DESCRIPTION
## Summary
- replace usages of the legacy Input Manager in grid placement and HUD scripts with Input System checks when active
- guard keyboard shortcuts with compile-time directives so controls work whether the new or legacy input backend is enabled

## Testing
- not run (Unity editor required)

------
https://chatgpt.com/codex/tasks/task_e_68cf27915c8c8333886e492935e67143