### PR TITLE
Add build menu and selection flow to dev bootstrap

### DIFF
--- a/Assets/Agents/AgentIntentDisplay.cs
+++ b/Assets/Agents/AgentIntentDisplay.cs
@@ -1,0 +1,101 @@
+using TMPro;
+using UnityEngine;
+
+namespace TavernSim.Agents
+{
+    /// <summary>
+    /// Spawns and orients a floating TextMeshPro label above an agent to describe its current intent.
+    /// </summary>
+    public sealed class AgentIntentDisplay : MonoBehaviour
+    {
+        [SerializeField] private Vector3 offset = new Vector3(0f, 2f, 0f);
+        [SerializeField] private float fontSize = 2f;
+        [SerializeField] private Color textColor = Color.white;
+
+        private TextMeshPro _label;
+        private Transform _labelTransform;
+        private Camera _camera;
+
+        private void Awake()
+        {
+            EnsureLabel();
+        }
+
+        private void OnEnable()
+        {
+            _camera = Camera.main;
+        }
+
+        private void LateUpdate()
+        {
+            if (_labelTransform == null)
+            {
+                return;
+            }
+
+            if (_camera == null || !_camera.isActiveAndEnabled)
+            {
+                _camera = Camera.main;
+                if (_camera == null)
+                {
+                    return;
+                }
+            }
+
+            var worldPosition = transform.position + offset;
+            _labelTransform.position = worldPosition;
+            var toCamera = _camera.transform.position - worldPosition;
+            if (toCamera.sqrMagnitude > Mathf.Epsilon)
+            {
+                _labelTransform.rotation = Quaternion.LookRotation(toCamera, Vector3.up);
+            }
+        }
+
+        public void SetIntent(string text)
+        {
+            EnsureLabel();
+            if (_label != null)
+            {
+                _label.text = text;
+            }
+        }
+
+        private void EnsureLabel()
+        {
+            if (_label != null)
+            {
+                return;
+            }
+
+            var go = new GameObject("IntentLabel");
+            go.transform.SetParent(transform, false);
+            go.transform.localPosition = offset;
+            _labelTransform = go.transform;
+
+            _label = go.AddComponent<TextMeshPro>();
+            _label.text = string.Empty;
+            _label.fontSize = fontSize;
+            _label.color = textColor;
+            _label.alignment = TextAlignmentOptions.Center;
+            _label.enableAutoSizing = false;
+            _label.sortingOrder = int.MaxValue;
+        }
+
+        private void OnDestroy()
+        {
+            if (_labelTransform == null)
+            {
+                return;
+            }
+
+            if (Application.isPlaying)
+            {
+                Destroy(_labelTransform.gameObject);
+            }
+            else
+            {
+                DestroyImmediate(_labelTransform.gameObject);
+            }
+        }
+    }
+}

--- a/Assets/Agents/Customer.cs
+++ b/Assets/Agents/Customer.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.AI; // Requires installing the AI Navigation package from the Package Manager.
+using TavernSim.Core;
 
 namespace TavernSim.Agents
 {
@@ -7,14 +8,19 @@ namespace TavernSim.Agents
     /// Simple NavMesh driven agent used by the AgentSystem to move customers through the tavern.
     /// </summary>
     [RequireComponent(typeof(NavMeshAgent))]
-    public sealed class Customer : MonoBehaviour
+    public sealed class Customer : MonoBehaviour, ISelectable
     {
         [SerializeField] private Animator animator;
+        [SerializeField] private AgentIntentDisplay intentDisplay;
 
         private NavMeshAgent _agent;
 
         public NavMeshAgent Agent => _agent;
         public Animator Animator => animator;
+
+        public string DisplayName => "Cliente";
+
+        public Transform Transform => transform;
 
         private void Awake()
         {
@@ -22,6 +28,11 @@ namespace TavernSim.Agents
             _agent.speed = 1.5f;
             _agent.angularSpeed = 720f;
             _agent.acceleration = 6f;
+
+            if (intentDisplay == null)
+            {
+                TryGetComponent(out intentDisplay);
+            }
         }
 
         public void SetDestination(Vector3 position)
@@ -81,6 +92,16 @@ namespace TavernSim.Agents
             {
                 _agent.ResetPath();
             }
+        }
+
+        public void SetIntent(string text)
+        {
+            if (intentDisplay == null)
+            {
+                TryGetComponent(out intentDisplay);
+            }
+
+            intentDisplay?.SetIntent(text);
         }
     }
 }

--- a/Assets/Agents/Waiter.cs
+++ b/Assets/Agents/Waiter.cs
@@ -1,12 +1,19 @@
 using UnityEngine;
 using UnityEngine.AI;
+using TavernSim.Core;
 
 namespace TavernSim.Agents
 {
     [RequireComponent(typeof(NavMeshAgent))]
-    public sealed class Waiter : MonoBehaviour
+    public sealed class Waiter : MonoBehaviour, ISelectable
     {
+        [SerializeField] private AgentIntentDisplay intentDisplay;
+
         private NavMeshAgent _agent;
+
+        public string DisplayName => "Garçom";
+
+        public Transform Transform => transform;
 
         private void Awake()
         {
@@ -14,6 +21,11 @@ namespace TavernSim.Agents
             _agent.angularSpeed = 720f;
             _agent.acceleration = 36f;
             _agent.stoppingDistance = 0.05f;
+
+            if (intentDisplay == null)
+            {
+                TryGetComponent(out intentDisplay);
+            }
         }
 
         public void SetDestination(Vector3 pos)
@@ -48,6 +60,16 @@ namespace TavernSim.Agents
             }
 
             return !_agent.hasPath || _agent.velocity.sqrMagnitude <= thresholdSqr;
+        }
+
+        public void SetIntent(string text)
+        {
+            if (intentDisplay == null)
+            {
+                TryGetComponent(out intentDisplay);
+            }
+
+            intentDisplay?.SetIntent(text);
         }
     }
 }

--- a/Assets/Bootstrap/FullCameraController.cs
+++ b/Assets/Bootstrap/FullCameraController.cs
@@ -1,5 +1,5 @@
 using UnityEngine;
-#if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
 using UnityEngine.InputSystem;
 #endif
 
@@ -76,7 +76,7 @@ namespace TavernSim.Bootstrap
         {
             Vector2 moveInput = Vector2.zero;
             bool boost = false;
-#if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
             var keyboard = Keyboard.current;
             if (keyboard != null)
             {
@@ -146,7 +146,7 @@ namespace TavernSim.Bootstrap
         private void HandleRotation()
         {
             float yawInput = 0f;
-#if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
             var keyboard = Keyboard.current;
             if (keyboard != null)
             {
@@ -170,6 +170,8 @@ namespace TavernSim.Bootstrap
             {
                 yawInput += 1f;
             }
+#else
+            return;
 #endif
 
             if (Mathf.Abs(yawInput) > 0.001f)
@@ -181,7 +183,7 @@ namespace TavernSim.Bootstrap
         private void HandleZoom()
         {
             float scroll = 0f;
-#if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
             var mouse = Mouse.current;
             if (mouse != null)
             {
@@ -189,6 +191,8 @@ namespace TavernSim.Bootstrap
             }
 #elif ENABLE_LEGACY_INPUT_MANAGER
             scroll = Input.mouseScrollDelta.y;
+#else
+            return;
 #endif
 
             if (Mathf.Abs(scroll) > 0.01f)
@@ -205,7 +209,7 @@ namespace TavernSim.Bootstrap
 
         private void HandlePointerInput()
         {
-#if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
             var mouse = Mouse.current;
             if (mouse == null)
             {

--- a/Assets/Bootstrap/FullCameraController.cs
+++ b/Assets/Bootstrap/FullCameraController.cs
@@ -1,5 +1,5 @@
 using UnityEngine;
-#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+#if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
 #endif
 
@@ -76,7 +76,7 @@ namespace TavernSim.Bootstrap
         {
             Vector2 moveInput = Vector2.zero;
             bool boost = false;
-#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+#if ENABLE_INPUT_SYSTEM
             var keyboard = Keyboard.current;
             if (keyboard != null)
             {
@@ -102,7 +102,7 @@ namespace TavernSim.Bootstrap
 
                 boost = keyboard.leftShiftKey.isPressed || keyboard.rightShiftKey.isPressed;
             }
-#else
+#elif ENABLE_LEGACY_INPUT_MANAGER
             if (Input.GetKey(KeyCode.W) || Input.GetKey(KeyCode.UpArrow))
             {
                 moveInput.y += 1f;
@@ -124,6 +124,8 @@ namespace TavernSim.Bootstrap
             }
 
             boost = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
+#else
+            return;
 #endif
 
             if (moveInput.sqrMagnitude > 1f)
@@ -144,7 +146,7 @@ namespace TavernSim.Bootstrap
         private void HandleRotation()
         {
             float yawInput = 0f;
-#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+#if ENABLE_INPUT_SYSTEM
             var keyboard = Keyboard.current;
             if (keyboard != null)
             {
@@ -158,7 +160,7 @@ namespace TavernSim.Bootstrap
                     yawInput += 1f;
                 }
             }
-#else
+#elif ENABLE_LEGACY_INPUT_MANAGER
             if (Input.GetKey(KeyCode.Q))
             {
                 yawInput -= 1f;
@@ -179,13 +181,13 @@ namespace TavernSim.Bootstrap
         private void HandleZoom()
         {
             float scroll = 0f;
-#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+#if ENABLE_INPUT_SYSTEM
             var mouse = Mouse.current;
             if (mouse != null)
             {
                 scroll = mouse.scroll.ReadValue().y;
             }
-#else
+#elif ENABLE_LEGACY_INPUT_MANAGER
             scroll = Input.mouseScrollDelta.y;
 #endif
 
@@ -203,7 +205,7 @@ namespace TavernSim.Bootstrap
 
         private void HandlePointerInput()
         {
-#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+#if ENABLE_INPUT_SYSTEM
             var mouse = Mouse.current;
             if (mouse == null)
             {
@@ -233,7 +235,7 @@ namespace TavernSim.Bootstrap
             }
 
             var pointer = mouse.position.ReadValue();
-#else
+#elif ENABLE_LEGACY_INPUT_MANAGER
             if (Input.GetMouseButtonDown(1))
             {
                 _isDragging = true;
@@ -255,6 +257,10 @@ namespace TavernSim.Bootstrap
             }
 
             var pointer = (Vector2)Input.mousePosition;
+#else
+            _isDragging = false;
+            _isOrbiting = false;
+            return;
 #endif
 
             if (_isDragging)

--- a/Assets/Bootstrap/FullCameraController.cs
+++ b/Assets/Bootstrap/FullCameraController.cs
@@ -1,0 +1,316 @@
+using UnityEngine;
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+using UnityEngine.InputSystem;
+#endif
+
+namespace TavernSim.Bootstrap
+{
+    /// <summary>
+    /// Provides feature-complete camera controls suitable for isometric gameplay prototypes.
+    /// Supports keyboard movement, scroll zoom, mouse drag panning, and orbit rotation while
+    /// remaining compatible with either the legacy input manager or the new Input System.
+    /// </summary>
+    [RequireComponent(typeof(Camera))]
+    public sealed class FullCameraController : MonoBehaviour
+    {
+        [Header("Movement")]
+        [SerializeField] private float moveSpeed = 8f;
+        [SerializeField] private float fastMoveMultiplier = 2f;
+        [SerializeField] private float dragSpeed = 6f;
+
+        [Header("Rotation")]
+        [SerializeField] private float rotationSpeed = 90f;
+        [SerializeField] private float orbitSpeed = 240f;
+        [SerializeField] private float minPitch = 35f;
+        [SerializeField] private float maxPitch = 75f;
+
+        [Header("Zoom")]
+        [SerializeField] private float zoomSpeed = 6f;
+        [SerializeField] private float zoomStep = 1.5f;
+        [SerializeField] private float minZoom = 4f;
+        [SerializeField] private float maxZoom = 30f;
+
+        private Vector3 _pivot;
+        private float _distance;
+        private float _targetDistance;
+        private float _yaw;
+        private float _pitch;
+        private bool _isDragging;
+        private bool _isOrbiting;
+        private Vector2 _lastPointer;
+
+        private void Start()
+        {
+            var rotation = transform.rotation.eulerAngles;
+            _yaw = rotation.y;
+            _pitch = Mathf.Clamp(rotation.x, minPitch, maxPitch);
+
+            var ray = new Ray(transform.position, transform.forward);
+            var plane = new Plane(Vector3.up, Vector3.zero);
+            if (!plane.Raycast(ray, out var hitDistance))
+            {
+                hitDistance = Mathf.Abs(transform.position.y);
+            }
+
+            _pivot = ray.GetPoint(hitDistance);
+            _pivot.y = 0f;
+
+            var offset = transform.position - _pivot;
+            _distance = Mathf.Clamp(offset.magnitude, minZoom, maxZoom);
+            _targetDistance = _distance;
+
+            ApplyTransform();
+        }
+
+        private void Update()
+        {
+            HandleKeyboardMovement();
+            HandleRotation();
+            HandleZoom();
+            HandlePointerInput();
+            SmoothZoom();
+            ApplyTransform();
+        }
+
+        private void HandleKeyboardMovement()
+        {
+            Vector2 moveInput = Vector2.zero;
+            bool boost = false;
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+            var keyboard = Keyboard.current;
+            if (keyboard != null)
+            {
+                if (keyboard.wKey.isPressed || keyboard.upArrowKey.isPressed)
+                {
+                    moveInput.y += 1f;
+                }
+
+                if (keyboard.sKey.isPressed || keyboard.downArrowKey.isPressed)
+                {
+                    moveInput.y -= 1f;
+                }
+
+                if (keyboard.dKey.isPressed || keyboard.rightArrowKey.isPressed)
+                {
+                    moveInput.x += 1f;
+                }
+
+                if (keyboard.aKey.isPressed || keyboard.leftArrowKey.isPressed)
+                {
+                    moveInput.x -= 1f;
+                }
+
+                boost = keyboard.leftShiftKey.isPressed || keyboard.rightShiftKey.isPressed;
+            }
+#else
+            if (Input.GetKey(KeyCode.W) || Input.GetKey(KeyCode.UpArrow))
+            {
+                moveInput.y += 1f;
+            }
+
+            if (Input.GetKey(KeyCode.S) || Input.GetKey(KeyCode.DownArrow))
+            {
+                moveInput.y -= 1f;
+            }
+
+            if (Input.GetKey(KeyCode.D) || Input.GetKey(KeyCode.RightArrow))
+            {
+                moveInput.x += 1f;
+            }
+
+            if (Input.GetKey(KeyCode.A) || Input.GetKey(KeyCode.LeftArrow))
+            {
+                moveInput.x -= 1f;
+            }
+
+            boost = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
+#endif
+
+            if (moveInput.sqrMagnitude > 1f)
+            {
+                moveInput.Normalize();
+            }
+
+            if (moveInput.sqrMagnitude > 0f)
+            {
+                var speed = moveSpeed * (boost ? fastMoveMultiplier : 1f);
+                var yawRotation = Quaternion.Euler(0f, _yaw, 0f);
+                var planarMove = yawRotation * new Vector3(moveInput.x, 0f, moveInput.y);
+                _pivot += planarMove * speed * Time.deltaTime;
+                _pivot.y = 0f;
+            }
+        }
+
+        private void HandleRotation()
+        {
+            float yawInput = 0f;
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+            var keyboard = Keyboard.current;
+            if (keyboard != null)
+            {
+                if (keyboard.qKey.isPressed)
+                {
+                    yawInput -= 1f;
+                }
+
+                if (keyboard.eKey.isPressed)
+                {
+                    yawInput += 1f;
+                }
+            }
+#else
+            if (Input.GetKey(KeyCode.Q))
+            {
+                yawInput -= 1f;
+            }
+
+            if (Input.GetKey(KeyCode.E))
+            {
+                yawInput += 1f;
+            }
+#endif
+
+            if (Mathf.Abs(yawInput) > 0.001f)
+            {
+                _yaw += yawInput * rotationSpeed * Time.deltaTime;
+            }
+        }
+
+        private void HandleZoom()
+        {
+            float scroll = 0f;
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+            var mouse = Mouse.current;
+            if (mouse != null)
+            {
+                scroll = mouse.scroll.ReadValue().y;
+            }
+#else
+            scroll = Input.mouseScrollDelta.y;
+#endif
+
+            if (Mathf.Abs(scroll) > 0.01f)
+            {
+                _targetDistance = Mathf.Clamp(_targetDistance - scroll * zoomStep, minZoom, maxZoom);
+            }
+        }
+
+        private void SmoothZoom()
+        {
+            _targetDistance = Mathf.Clamp(_targetDistance, minZoom, maxZoom);
+            _distance = Mathf.MoveTowards(_distance, _targetDistance, zoomSpeed * Time.deltaTime);
+        }
+
+        private void HandlePointerInput()
+        {
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+            var mouse = Mouse.current;
+            if (mouse == null)
+            {
+                _isDragging = false;
+                _isOrbiting = false;
+                return;
+            }
+
+            if (mouse.rightButton.wasPressedThisFrame)
+            {
+                _isDragging = true;
+                _lastPointer = mouse.position.ReadValue();
+            }
+            else if (mouse.rightButton.wasReleasedThisFrame)
+            {
+                _isDragging = false;
+            }
+
+            if (mouse.middleButton.wasPressedThisFrame)
+            {
+                _isOrbiting = true;
+                _lastPointer = mouse.position.ReadValue();
+            }
+            else if (mouse.middleButton.wasReleasedThisFrame)
+            {
+                _isOrbiting = false;
+            }
+
+            var pointer = mouse.position.ReadValue();
+#else
+            if (Input.GetMouseButtonDown(1))
+            {
+                _isDragging = true;
+                _lastPointer = Input.mousePosition;
+            }
+            else if (Input.GetMouseButtonUp(1))
+            {
+                _isDragging = false;
+            }
+
+            if (Input.GetMouseButtonDown(2))
+            {
+                _isOrbiting = true;
+                _lastPointer = Input.mousePosition;
+            }
+            else if (Input.GetMouseButtonUp(2))
+            {
+                _isOrbiting = false;
+            }
+
+            var pointer = (Vector2)Input.mousePosition;
+#endif
+
+            if (_isDragging)
+            {
+                ApplyDrag(pointer - _lastPointer);
+                _lastPointer = pointer;
+            }
+
+            if (_isOrbiting)
+            {
+                ApplyOrbit(pointer - _lastPointer);
+                _lastPointer = pointer;
+            }
+        }
+
+        private void ApplyDrag(Vector2 delta)
+        {
+            if (delta.sqrMagnitude < Mathf.Epsilon)
+            {
+                return;
+            }
+
+            var width = Screen.width > 0 ? Screen.width : 1;
+            var height = Screen.height > 0 ? Screen.height : 1;
+            var normalized = new Vector2(delta.x / width, delta.y / height);
+            var yawRotation = Quaternion.Euler(0f, _yaw, 0f);
+            var right = yawRotation * Vector3.right;
+            var forward = yawRotation * Vector3.forward;
+            var movement = (-right * normalized.x - forward * normalized.y) * dragSpeed * _distance;
+            _pivot += movement;
+            _pivot.y = 0f;
+        }
+
+        private void ApplyOrbit(Vector2 delta)
+        {
+            if (delta.sqrMagnitude < Mathf.Epsilon)
+            {
+                return;
+            }
+
+            var width = Screen.width > 0 ? Screen.width : 1;
+            var height = Screen.height > 0 ? Screen.height : 1;
+            _yaw += (delta.x / width) * orbitSpeed;
+            _pitch -= (delta.y / height) * orbitSpeed;
+            _pitch = Mathf.Clamp(_pitch, minPitch, maxPitch);
+        }
+
+        private void ApplyTransform()
+        {
+            _pitch = Mathf.Clamp(_pitch, minPitch, maxPitch);
+            _distance = Mathf.Clamp(_distance, minZoom, maxZoom);
+
+            var rotation = Quaternion.Euler(_pitch, _yaw, 0f);
+            var forward = rotation * Vector3.forward;
+            var position = _pivot - forward * _distance;
+            transform.SetPositionAndRotation(position, rotation);
+        }
+    }
+}

--- a/Assets/Building/GridPlacer.cs
+++ b/Assets/Building/GridPlacer.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using TavernSim.Core;
 using TavernSim.Simulation.Systems;
-#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+#if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
 #endif
 
@@ -48,7 +48,7 @@ namespace TavernSim.Building
                 return;
             }
 
-#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+#if ENABLE_INPUT_SYSTEM
             var mouse = Mouse.current;
             var keyboard = Keyboard.current;
             if (mouse == null)
@@ -69,7 +69,7 @@ namespace TavernSim.Building
 
             var pointerPosition = mouse.position.ReadValue();
             var screenPoint = new Vector3(pointerPosition.x, pointerPosition.y, 0f);
-#else
+#elif ENABLE_LEGACY_INPUT_MANAGER
             if (HasActivePlacement && (Input.GetMouseButtonDown(1) || Input.GetKeyDown(KeyCode.Escape)))
             {
                 CancelPlacement();
@@ -82,6 +82,8 @@ namespace TavernSim.Building
             }
 
             var screenPoint = Input.mousePosition;
+#else
+            return;
 #endif
 
             var mainCamera = Camera.main;

--- a/Assets/Building/GridPlacer.cs
+++ b/Assets/Building/GridPlacer.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using TavernSim.Core;
 using TavernSim.Simulation.Systems;
-#if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
 using UnityEngine.InputSystem;
 #endif
 
@@ -48,7 +48,7 @@ namespace TavernSim.Building
                 return;
             }
 
-#if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
             var mouse = Mouse.current;
             var keyboard = Keyboard.current;
             if (mouse == null)

--- a/Assets/Building/GridPlacer.cs
+++ b/Assets/Building/GridPlacer.cs
@@ -1,5 +1,9 @@
 using UnityEngine;
+using TavernSim.Core;
 using TavernSim.Simulation.Systems;
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+using UnityEngine.InputSystem;
+#endif
 
 namespace TavernSim.Building
 {
@@ -8,41 +12,248 @@ namespace TavernSim.Building
     /// </summary>
     public sealed class GridPlacer : MonoBehaviour
     {
+        public enum PlaceableKind
+        {
+            None = 0,
+            Table = 1,
+            Chair = 2,
+            Decoration = 3
+        }
+
         [SerializeField] private float gridSize = 1f;
-        [SerializeField] private float propCost = 25f;
+        [SerializeField] private float tableCost = 125f;
+        [SerializeField] private float chairCost = 45f;
+        [SerializeField] private float decorationCost = 30f;
 
         private EconomySystem _economySystem;
+        private SelectionService _selectionService;
+        private PlaceableKind _activeKind = PlaceableKind.None;
 
-        public void Configure(EconomySystem economySystem)
+        public event System.Action<PlaceableKind> PlacementModeChanged;
+
+        public PlaceableKind ActiveKind => _activeKind;
+
+        public bool HasActivePlacement => _activeKind != PlaceableKind.None;
+
+        public void Configure(EconomySystem economySystem, SelectionService selectionService)
         {
             _economySystem = economySystem;
+            _selectionService = selectionService;
         }
 
         private void Update()
+        {
+            if (_selectionService == null)
+            {
+                return;
+            }
+
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+            var mouse = Mouse.current;
+            var keyboard = Keyboard.current;
+            if (mouse == null)
+            {
+                return;
+            }
+
+            if (HasActivePlacement && (mouse.rightButton.wasPressedThisFrame || (keyboard != null && keyboard.escapeKey.wasPressedThisFrame)))
+            {
+                CancelPlacement();
+                return;
+            }
+
+            if (!mouse.leftButton.wasPressedThisFrame)
+            {
+                return;
+            }
+
+            var pointerPosition = mouse.position.ReadValue();
+            var screenPoint = new Vector3(pointerPosition.x, pointerPosition.y, 0f);
+#else
+            if (HasActivePlacement && (Input.GetMouseButtonDown(1) || Input.GetKeyDown(KeyCode.Escape)))
+            {
+                CancelPlacement();
+                return;
+            }
+
+            if (!Input.GetMouseButtonDown(0))
+            {
+                return;
+            }
+
+            var screenPoint = Input.mousePosition;
+#endif
+
+            var mainCamera = Camera.main;
+            if (mainCamera == null)
+            {
+                return;
+            }
+
+            var ray = mainCamera.ScreenPointToRay(screenPoint);
+            if (!Physics.Raycast(ray, out var hit, 100f))
+            {
+                if (!HasActivePlacement)
+                {
+                    _selectionService.ClearSelection();
+                }
+
+                return;
+            }
+
+            if (HasActivePlacement)
+            {
+                TryPlaceAt(hit.point);
+            }
+            else
+            {
+                SelectHit(hit.collider);
+            }
+        }
+
+        public void BeginPlacement(PlaceableKind kind)
+        {
+            if (kind == PlaceableKind.None)
+            {
+                CancelPlacement();
+                return;
+            }
+
+            _selectionService?.ClearSelection();
+            _activeKind = kind;
+            PlacementModeChanged?.Invoke(_activeKind);
+        }
+
+        public void CancelPlacement()
+        {
+            if (_activeKind == PlaceableKind.None)
+            {
+                return;
+            }
+
+            _activeKind = PlaceableKind.None;
+            PlacementModeChanged?.Invoke(_activeKind);
+        }
+
+        public float GetPlacementCost(PlaceableKind kind)
+        {
+            return kind switch
+            {
+                PlaceableKind.Table => tableCost,
+                PlaceableKind.Chair => chairCost,
+                PlaceableKind.Decoration => decorationCost,
+                _ => 0f
+            };
+        }
+
+        private void TryPlaceAt(Vector3 point)
         {
             if (_economySystem == null)
             {
                 return;
             }
 
-            if (Input.GetMouseButtonDown(0))
+            var cost = GetPlacementCost(_activeKind);
+            if (cost > 0f && !_economySystem.TrySpend(cost))
             {
-                var ray = Camera.main != null ? Camera.main.ScreenPointToRay(Input.mousePosition) : default;
-                if (Physics.Raycast(ray, out var hit, 100f))
-                {
-                    var position = hit.point;
-                    position.x = Mathf.Round(position.x / gridSize) * gridSize;
-                    position.z = Mathf.Round(position.z / gridSize) * gridSize;
-                    position.y = 0f;
-
-                    if (_economySystem.TrySpend(propCost))
-                    {
-                        var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                        cube.transform.position = position;
-                        cube.transform.localScale = new Vector3(1f, 0.5f, 1f);
-                    }
-                }
+                Debug.LogWarning($"Not enough cash to place {_activeKind} (cost {cost:0}).");
+                return;
             }
+
+            var position = AlignToGrid(point);
+            switch (_activeKind)
+            {
+                case PlaceableKind.Table:
+                    CreateTable(position);
+                    break;
+                case PlaceableKind.Chair:
+                    CreateChair(position);
+                    break;
+                case PlaceableKind.Decoration:
+                    CreateDecoration(position);
+                    break;
+            }
+        }
+
+        private void SelectHit(Collider collider)
+        {
+            if (collider == null)
+            {
+                _selectionService.ClearSelection();
+                return;
+            }
+
+            var selectable = collider.GetComponentInParent<ISelectable>();
+            if (selectable != null)
+            {
+                _selectionService.Select(selectable);
+            }
+            else
+            {
+                _selectionService.ClearSelection();
+            }
+        }
+
+        private Vector3 AlignToGrid(Vector3 point)
+        {
+            var position = point;
+            position.x = Mathf.Round(position.x / gridSize) * gridSize;
+            position.z = Mathf.Round(position.z / gridSize) * gridSize;
+            position.y = 0f;
+            return position;
+        }
+
+        private static void CreateTable(Vector3 position)
+        {
+            var tableTop = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            tableTop.name = "Table";
+            tableTop.transform.position = position + new Vector3(0f, 0.55f, 0f);
+            tableTop.transform.localScale = new Vector3(1.4f, 0.1f, 1.4f);
+            NavMeshSetup.MarkObstacle(tableTop);
+
+            CreateTableLeg(tableTop.transform, new Vector3(0.55f, -0.55f, 0.55f));
+            CreateTableLeg(tableTop.transform, new Vector3(-0.55f, -0.55f, 0.55f));
+            CreateTableLeg(tableTop.transform, new Vector3(0.55f, -0.55f, -0.55f));
+            CreateTableLeg(tableTop.transform, new Vector3(-0.55f, -0.55f, -0.55f));
+        }
+
+        private static void CreateTableLeg(Transform parent, Vector3 localPosition)
+        {
+            var leg = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            leg.name = "TableLeg";
+            leg.transform.SetParent(parent, false);
+            leg.transform.localPosition = localPosition;
+            leg.transform.localScale = new Vector3(0.15f, 1.1f, 0.15f);
+        }
+
+        private static void CreateChair(Vector3 position)
+        {
+            var seat = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            seat.name = "Chair";
+            seat.transform.position = position + new Vector3(0f, 0.25f, 0f);
+            seat.transform.localScale = new Vector3(0.6f, 0.5f, 0.6f);
+            NavMeshSetup.MarkObstacle(seat);
+
+            var back = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            back.name = "ChairBack";
+            back.transform.SetParent(seat.transform, false);
+            back.transform.localPosition = new Vector3(0f, 0.6f, -0.3f);
+            back.transform.localScale = new Vector3(0.6f, 1.2f, 0.2f);
+        }
+
+        private static void CreateDecoration(Vector3 position)
+        {
+            var planter = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
+            planter.name = "Plant";
+            planter.transform.position = position + new Vector3(0f, 0.3f, 0f);
+            planter.transform.localScale = new Vector3(0.5f, 0.3f, 0.5f);
+            NavMeshSetup.MarkObstacle(planter, false);
+
+            var foliage = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            foliage.name = "Foliage";
+            foliage.transform.SetParent(planter.transform, false);
+            foliage.transform.localPosition = new Vector3(0f, 0.9f, 0f);
+            foliage.transform.localScale = new Vector3(1.4f, 1.4f, 1.4f);
         }
     }
 }

--- a/Assets/Core/ISelectable.cs
+++ b/Assets/Core/ISelectable.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+namespace TavernSim.Core
+{
+    /// <summary>
+    /// Represents an entity that can be selected by the player in debug tooling.
+    /// </summary>
+    public interface ISelectable
+    {
+        string DisplayName { get; }
+
+        Transform Transform { get; }
+    }
+}

--- a/Assets/Core/SelectionService.cs
+++ b/Assets/Core/SelectionService.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace TavernSim.Core
+{
+    /// <summary>
+    /// Maintains the current selection and notifies listeners when it changes.
+    /// </summary>
+    public sealed class SelectionService
+    {
+        private ISelectable _current;
+
+        public event Action<ISelectable> SelectionChanged;
+
+        public ISelectable Current => _current;
+
+        public void Select(ISelectable selectable)
+        {
+            if (_current == selectable)
+            {
+                return;
+            }
+
+            _current = selectable;
+            SelectionChanged?.Invoke(_current);
+        }
+
+        public void ClearSelection()
+        {
+            if (_current == null)
+            {
+                return;
+            }
+
+            _current = null;
+            SelectionChanged?.Invoke(null);
+        }
+    }
+}

--- a/Assets/Simulation/Systems/AgentSystem.cs
+++ b/Assets/Simulation/Systems/AgentSystem.cs
@@ -94,7 +94,9 @@ namespace TavernSim.Simulation.Systems
                 return;
             }
 
-            _waiters.Add(new WaiterData(waiter));
+            var data = new WaiterData(waiter);
+            _waiters.Add(data);
+            UpdateWaiterIntent(data);
         }
 
         public void SpawnCustomer(Customer customer)
@@ -114,6 +116,7 @@ namespace TavernSim.Simulation.Systems
             customer.SetDestination(_entryPoint);
             _customers.Add(data);
             ActiveCustomerCountChanged?.Invoke(_customers.Count);
+            UpdateCustomerIntent(data);
         }
 
         private void MarkForDespawn(CustomerData data)
@@ -184,6 +187,7 @@ namespace TavernSim.Simulation.Systems
                         break;
                 }
 
+                UpdateCustomerIntent(data);
                 _customers[i] = data;
             }
         }
@@ -213,6 +217,7 @@ namespace TavernSim.Simulation.Systems
                         break;
                 }
 
+                UpdateWaiterIntent(data);
                 _waiters[i] = data;
             }
         }
@@ -490,6 +495,60 @@ namespace TavernSim.Simulation.Systems
             }
 
             return Mathf.Lerp(2f, 0f, (waitTime - 10f) / 15f);
+        }
+
+        private static void UpdateCustomerIntent(CustomerData data)
+        {
+            data.Agent?.SetIntent(GetCustomerIntent(data.State));
+        }
+
+        private static void UpdateWaiterIntent(WaiterData data)
+        {
+            data.Agent?.SetIntent(GetWaiterIntent(data.State));
+        }
+
+        private static string GetCustomerIntent(CustomerState state)
+        {
+            switch (state)
+            {
+                case CustomerState.Enter:
+                    return "Entrando";
+                case CustomerState.FindTable:
+                    return "Procurando mesa";
+                case CustomerState.Sit:
+                    return "Sentando";
+                case CustomerState.Order:
+                    return "Fazendo pedido";
+                case CustomerState.WaitDrink:
+                    return "Esperando bebida";
+                case CustomerState.Drink:
+                    return "Bebendo";
+                case CustomerState.Pay:
+                    return "Pagando";
+                case CustomerState.Leave:
+                    return "Saindo";
+                default:
+                    return string.Empty;
+            }
+        }
+
+        private static string GetWaiterIntent(WaiterState state)
+        {
+            switch (state)
+            {
+                case WaiterState.Idle:
+                    return "Disponível";
+                case WaiterState.TakeOrder:
+                    return "Anotando pedido";
+                case WaiterState.WaitPrep:
+                    return "Aguardando preparo";
+                case WaiterState.Deliver:
+                    return "Servindo";
+                case WaiterState.Clean:
+                    return "Limpando";
+                default:
+                    return string.Empty;
+            }
         }
 
         private enum CustomerState

--- a/Assets/UI/HUDController.cs
+++ b/Assets/UI/HUDController.cs
@@ -5,7 +5,7 @@ using TavernSim.Save;
 using TavernSim.Simulation.Systems;
 using TavernSim.Building;
 using TavernSim.Core;
-#if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
 using UnityEngine.InputSystem;
 #endif
 
@@ -120,7 +120,7 @@ namespace TavernSim.UI
                 return;
             }
 
-#if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
             var keyboard = Keyboard.current;
             if (keyboard == null)
             {
@@ -146,6 +146,8 @@ namespace TavernSim.UI
             {
                 LoadGame();
             }
+#else
+            return;
 #endif
         }
 

--- a/Assets/UI/HUDController.cs
+++ b/Assets/UI/HUDController.cs
@@ -3,6 +3,11 @@ using UnityEngine;
 using UnityEngine.UIElements;
 using TavernSim.Save;
 using TavernSim.Simulation.Systems;
+using TavernSim.Building;
+using TavernSim.Core;
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+using UnityEngine.InputSystem;
+#endif
 
 namespace TavernSim.UI
 {
@@ -19,12 +24,30 @@ namespace TavernSim.UI
         private SaveService _saveService;
 
         private UIDocument _document;
+        private Label _controlsLabel;
         private Label _cashLabel;
         private Label _customerLabel;
+        private Label _selectionLabel;
         private ScrollView _ordersScroll;
         private Button _saveButton;
         private Button _loadButton;
+        private Button _buildToggleButton;
+        private VisualElement _buildMenu;
         private readonly List<Label> _orderEntries = new List<Label>(16);
+        private readonly List<Button> _buildOptionButtons = new List<Button>();
+        private readonly Dictionary<Button, BuildOption> _buildOptionLookup = new Dictionary<Button, BuildOption>();
+        private EventCallback<ClickEvent> _buildOptionHandler;
+        private bool _buildMenuVisible;
+
+        private SelectionService _selectionService;
+        private GridPlacer _gridPlacer;
+
+        private static readonly BuildOption[] BuildOptions =
+        {
+            new BuildOption("buildTableBtn", "Mesa", GridPlacer.PlaceableKind.Table),
+            new BuildOption("buildChairBtn", "Cadeira", GridPlacer.PlaceableKind.Chair),
+            new BuildOption("buildDecorBtn", "Planta", GridPlacer.PlaceableKind.Decoration)
+        };
 
         public void Initialize(EconomySystem economySystem, OrderSystem orderSystem)
         {
@@ -40,6 +63,33 @@ namespace TavernSim.UI
         public void BindSaveService(SaveService saveService)
         {
             _saveService = saveService;
+        }
+
+        public void BindSelection(SelectionService selectionService, GridPlacer gridPlacer)
+        {
+            var changed = _selectionService != selectionService || _gridPlacer != gridPlacer;
+            if (!changed)
+            {
+                return;
+            }
+
+            if (isActiveAndEnabled)
+            {
+                UnhookEvents();
+            }
+
+            _selectionService = selectionService;
+            _gridPlacer = gridPlacer;
+
+            RefreshBuildOptionLabels();
+            HighlightActiveOption(_gridPlacer != null ? _gridPlacer.ActiveKind : GridPlacer.PlaceableKind.None);
+            UpdateSelectionLabel(_selectionService != null ? _selectionService.Current : null);
+            SetBuildMenuVisible(false);
+
+            if (isActiveAndEnabled)
+            {
+                HookEvents();
+            }
         }
 
         private void Awake()
@@ -70,6 +120,23 @@ namespace TavernSim.UI
                 return;
             }
 
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+            var keyboard = Keyboard.current;
+            if (keyboard == null)
+            {
+                return;
+            }
+
+            if (keyboard.f5Key.wasPressedThisFrame)
+            {
+                SaveGame();
+            }
+
+            if (keyboard.f9Key.wasPressedThisFrame)
+            {
+                LoadGame();
+            }
+#else
             if (Input.GetKeyDown(KeyCode.F5))
             {
                 SaveGame();
@@ -79,6 +146,7 @@ namespace TavernSim.UI
             {
                 LoadGame();
             }
+#endif
         }
 
         public void SetCustomers(int count)
@@ -117,11 +185,20 @@ namespace TavernSim.UI
                 rootElement = fallbackRoot;
             }
 
+            _controlsLabel = rootElement.Q<Label>("controlsLabel") ?? CreateLabel(rootElement, "controlsLabel", string.Empty);
+            _controlsLabel.text = GetControlsSummary();
+
             _cashLabel = rootElement.Q<Label>("cashLabel") ?? CreateLabel(rootElement, "cashLabel", "Cash: 0");
             _customerLabel = rootElement.Q<Label>("customerLabel") ?? CreateLabel(rootElement, "customerLabel", "Customers: 0");
             _ordersScroll = rootElement.Q<ScrollView>("ordersScroll") ?? CreateScroll(rootElement);
             _saveButton = rootElement.Q<Button>("saveBtn") ?? CreateButton(rootElement, "saveBtn", "Save (F5)");
             _loadButton = rootElement.Q<Button>("loadBtn") ?? CreateButton(rootElement, "loadBtn", "Load (F9)");
+            _selectionLabel = rootElement.Q<Label>("selectionLabel") ?? CreateLabel(rootElement, "selectionLabel", "Selecionado: Nenhum");
+            _buildToggleButton = rootElement.Q<Button>("buildToggleBtn") ?? CreateButton(rootElement, "buildToggleBtn", "Construir");
+            _buildMenu = rootElement.Q<VisualElement>("buildMenu") ?? CreateBuildMenu(rootElement);
+
+            CreateBuildButtons();
+            SetBuildMenuVisible(false);
         }
 
         private void HookEvents()
@@ -151,6 +228,28 @@ namespace TavernSim.UI
                 _loadButton.clicked -= LoadGame;
                 _loadButton.clicked += LoadGame;
             }
+
+            if (_buildToggleButton != null)
+            {
+                _buildToggleButton.clicked -= ToggleBuildMenu;
+                _buildToggleButton.clicked += ToggleBuildMenu;
+            }
+
+            if (_selectionService != null)
+            {
+                _selectionService.SelectionChanged -= OnSelectionChanged;
+                _selectionService.SelectionChanged += OnSelectionChanged;
+                OnSelectionChanged(_selectionService.Current);
+            }
+
+            if (_gridPlacer != null)
+            {
+                _gridPlacer.PlacementModeChanged -= OnPlacementModeChanged;
+                _gridPlacer.PlacementModeChanged += OnPlacementModeChanged;
+                OnPlacementModeChanged(_gridPlacer.ActiveKind);
+            }
+
+            AttachBuildOptionCallbacks();
         }
 
         private void UnhookEvents()
@@ -174,6 +273,23 @@ namespace TavernSim.UI
             {
                 _loadButton.clicked -= LoadGame;
             }
+
+            if (_buildToggleButton != null)
+            {
+                _buildToggleButton.clicked -= ToggleBuildMenu;
+            }
+
+            if (_selectionService != null)
+            {
+                _selectionService.SelectionChanged -= OnSelectionChanged;
+            }
+
+            if (_gridPlacer != null)
+            {
+                _gridPlacer.PlacementModeChanged -= OnPlacementModeChanged;
+            }
+
+            DetachBuildOptionCallbacks();
         }
 
         private void OnCashChanged(float value)
@@ -234,6 +350,147 @@ namespace TavernSim.UI
             Debug.Log($"Game loaded from {path}");
         }
 
+        private void ToggleBuildMenu()
+        {
+            SetBuildMenuVisible(!_buildMenuVisible);
+        }
+
+        private void SetBuildMenuVisible(bool visible)
+        {
+            _buildMenuVisible = visible;
+            if (_buildMenu != null)
+            {
+                _buildMenu.style.display = visible ? DisplayStyle.Flex : DisplayStyle.None;
+            }
+        }
+
+        private void AttachBuildOptionCallbacks()
+        {
+            if (_buildMenu == null || _buildOptionButtons.Count == 0)
+            {
+                return;
+            }
+
+            _buildOptionHandler ??= OnBuildOptionClicked;
+            foreach (var button in _buildOptionButtons)
+            {
+                button.UnregisterCallback(_buildOptionHandler);
+                button.RegisterCallback(_buildOptionHandler);
+            }
+        }
+
+        private void DetachBuildOptionCallbacks()
+        {
+            if (_buildOptionHandler == null)
+            {
+                return;
+            }
+
+            foreach (var button in _buildOptionButtons)
+            {
+                button.UnregisterCallback(_buildOptionHandler);
+            }
+        }
+
+        private void OnBuildOptionClicked(ClickEvent evt)
+        {
+            if (_gridPlacer == null)
+            {
+                return;
+            }
+
+            if (evt.currentTarget is Button optionButton && optionButton.userData is GridPlacer.PlaceableKind kind)
+            {
+                if (_gridPlacer.ActiveKind == kind)
+                {
+                    _gridPlacer.CancelPlacement();
+                }
+                else
+                {
+                    _gridPlacer.BeginPlacement(kind);
+                }
+
+                HighlightActiveOption(_gridPlacer.ActiveKind);
+                SetBuildMenuVisible(false);
+            }
+        }
+
+        private void OnSelectionChanged(ISelectable selectable)
+        {
+            UpdateSelectionLabel(selectable);
+        }
+
+        private void UpdateSelectionLabel(ISelectable selectable)
+        {
+            if (_selectionLabel == null)
+            {
+                return;
+            }
+
+            _selectionLabel.text = selectable != null
+                ? $"Selecionado: {selectable.DisplayName}"
+                : "Selecionado: Nenhum";
+        }
+
+        private void OnPlacementModeChanged(GridPlacer.PlaceableKind kind)
+        {
+            HighlightActiveOption(kind);
+        }
+
+        private void HighlightActiveOption(GridPlacer.PlaceableKind kind)
+        {
+            foreach (var button in _buildOptionButtons)
+            {
+                if (button.userData is GridPlacer.PlaceableKind buttonKind && buttonKind == kind)
+                {
+                    button.AddToClassList("build-option--active");
+                }
+                else
+                {
+                    button.RemoveFromClassList("build-option--active");
+                }
+            }
+        }
+
+        private void RefreshBuildOptionLabels()
+        {
+            foreach (var pair in _buildOptionLookup)
+            {
+                var option = pair.Value;
+                var cost = _gridPlacer != null ? _gridPlacer.GetPlacementCost(option.Kind) : 0f;
+                pair.Key.text = cost > 0f ? $"{option.Label} ({cost:0})" : option.Label;
+            }
+        }
+
+        private void CreateBuildButtons()
+        {
+            if (_buildMenu == null)
+            {
+                return;
+            }
+
+            _buildMenu.Clear();
+            _buildOptionButtons.Clear();
+            _buildOptionLookup.Clear();
+
+            foreach (var option in BuildOptions)
+            {
+                var button = new Button
+                {
+                    name = option.Name,
+                    text = option.Label,
+                    userData = option.Kind
+                };
+                button.AddToClassList("build-option");
+                _buildMenu.Add(button);
+                _buildOptionButtons.Add(button);
+                _buildOptionLookup[button] = option;
+            }
+
+            RefreshBuildOptionLabels();
+            HighlightActiveOption(GridPlacer.PlaceableKind.None);
+        }
+
         private static Label CreateLabel(VisualElement root, string name, string text)
         {
             var label = new Label(text) { name = name };
@@ -253,6 +510,32 @@ namespace TavernSim.UI
             var button = new Button { name = name, text = text };
             root.Add(button);
             return button;
+        }
+
+        private static VisualElement CreateBuildMenu(VisualElement root)
+        {
+            var container = new VisualElement { name = "buildMenu" };
+            root.Add(container);
+            return container;
+        }
+
+        private static string GetControlsSummary()
+        {
+            return "Camera: WASD/Arrows move • Shift sprint • Scroll zoom • Right Drag pan • Middle Drag orbit • Q/E rotate • Left Click select • Build button to place props";
+        }
+
+        private readonly struct BuildOption
+        {
+            public readonly string Name;
+            public readonly string Label;
+            public readonly GridPlacer.PlaceableKind Kind;
+
+            public BuildOption(string name, string label, GridPlacer.PlaceableKind kind)
+            {
+                Name = name;
+                Label = label;
+                Kind = kind;
+            }
         }
     }
 }

--- a/Assets/UI/HUDController.cs
+++ b/Assets/UI/HUDController.cs
@@ -5,7 +5,7 @@ using TavernSim.Save;
 using TavernSim.Simulation.Systems;
 using TavernSim.Building;
 using TavernSim.Core;
-#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+#if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
 #endif
 
@@ -120,7 +120,7 @@ namespace TavernSim.UI
                 return;
             }
 
-#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+#if ENABLE_INPUT_SYSTEM
             var keyboard = Keyboard.current;
             if (keyboard == null)
             {
@@ -136,7 +136,7 @@ namespace TavernSim.UI
             {
                 LoadGame();
             }
-#else
+#elif ENABLE_LEGACY_INPUT_MANAGER
             if (Input.GetKeyDown(KeyCode.F5))
             {
                 SaveGame();

--- a/Assets/UI/TimeControls.cs
+++ b/Assets/UI/TimeControls.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 using UnityEngine.UIElements;
-#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+#if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
 #endif
 
@@ -28,13 +28,13 @@ namespace TavernSim.UI
 
         private void Update()
         {
-#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+#if ENABLE_INPUT_SYSTEM
             var keyboard = Keyboard.current;
             if (keyboard != null && keyboard.spaceKey.wasPressedThisFrame)
             {
                 TogglePause();
             }
-#else
+#elif ENABLE_LEGACY_INPUT_MANAGER
             if (Input.GetKeyDown(KeyCode.Space))
             {
                 TogglePause();

--- a/Assets/UI/TimeControls.cs
+++ b/Assets/UI/TimeControls.cs
@@ -1,5 +1,8 @@
 using UnityEngine;
 using UnityEngine.UIElements;
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+using UnityEngine.InputSystem;
+#endif
 
 namespace TavernSim.UI
 {
@@ -25,10 +28,18 @@ namespace TavernSim.UI
 
         private void Update()
         {
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+            var keyboard = Keyboard.current;
+            if (keyboard != null && keyboard.spaceKey.wasPressedThisFrame)
+            {
+                TogglePause();
+            }
+#else
             if (Input.GetKeyDown(KeyCode.Space))
             {
                 TogglePause();
             }
+#endif
         }
 
         private void Hook()

--- a/Assets/UI/TimeControls.cs
+++ b/Assets/UI/TimeControls.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 using UnityEngine.UIElements;
-#if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
 using UnityEngine.InputSystem;
 #endif
 
@@ -28,7 +28,7 @@ namespace TavernSim.UI
 
         private void Update()
         {
-#if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
             var keyboard = Keyboard.current;
             if (keyboard != null && keyboard.spaceKey.wasPressedThisFrame)
             {
@@ -39,6 +39,8 @@ namespace TavernSim.UI
             {
                 TogglePause();
             }
+#else
+            return;
 #endif
         }
 

--- a/Assets/UI/USS/HUD.uss
+++ b/Assets/UI/USS/HUD.uss
@@ -36,3 +36,38 @@
 .save-controls button {
     flex-grow: 1;
 }
+
+.selection {
+    margin-top: 6px;
+    font-size: 13px;
+    color: #d0d0d0;
+}
+
+.build-controls {
+    margin-top: 6px;
+    flex-direction: column;
+}
+
+.build-controls > * + * {
+    margin-top: 4px;
+}
+
+.build-menu {
+    background-color: rgba(255, 255, 255, 0.05);
+    border-radius: 4px;
+    padding: 4px;
+    flex-direction: column;
+}
+
+.build-menu button + button {
+    margin-top: 4px;
+}
+
+.build-option {
+    justify-content: flex-start;
+}
+
+.build-option--active {
+    background-color: rgba(255, 255, 255, 0.18);
+    color: #ffffff;
+}

--- a/Assets/UI/UXML/HUD.uxml
+++ b/Assets/UI/UXML/HUD.uxml
@@ -15,5 +15,10 @@
       <ui:Button name="saveBtn" text="Save (F5)" />
       <ui:Button name="loadBtn" text="Load (F9)" />
     </ui:VisualElement>
+    <ui:Label name="selectionLabel" class="stat selection" text="Selecionado: Nenhum" />
+    <ui:VisualElement name="buildControls" class="build-controls">
+      <ui:Button name="buildToggleBtn" text="Construir" />
+      <ui:VisualElement name="buildMenu" class="build-menu" />
+    </ui:VisualElement>
   </ui:VisualElement>
 </engine:UXML>


### PR DESCRIPTION
## Summary
- introduce a selection service and implement ISelectable on waiters and customers so left-click focuses agents instead of placing props by default
- replace the grid placer with a placement-mode workflow that only spawns tables, chairs, or plants after choosing an option from the new HUD build menu
- expand the HUD layout to show the current selection, expose the build controls, and hook DevBootstrap into the new camera and placement systems

## Testing
- not run (Unity editor required)

------
https://chatgpt.com/codex/tasks/task_e_68cf27915c8c8333886e492935e67143