### PR TITLE
Fix HUD USS selectors and panel settings type

### DIFF
--- a/Assets/Bootstrap/DevBootstrap.cs
+++ b/Assets/Bootstrap/DevBootstrap.cs
@@ -234,7 +234,7 @@ namespace TavernSim.Bootstrap
                 _panelSettings.name = "DevBootstrapPanelSettings";
                 _panelSettings.hideFlags = HideFlags.HideAndDontSave;
                 _panelSettings.scaleMode = PanelScaleMode.ScaleWithScreenSize;
-                _panelSettings.referenceResolution = new Vector2(1920f, 1080f);
+                _panelSettings.referenceResolution = new Vector2Int(1920, 1080);
                 _panelSettings.sortingOrder = 100;
                 _panelSettings.targetTexture = null;
             }

--- a/Assets/UI/HUDController.cs
+++ b/Assets/UI/HUDController.cs
@@ -485,6 +485,10 @@ namespace TavernSim.UI
                     userData = option.Kind
                 };
                 button.AddToClassList("build-option");
+                if (_buildOptionButtons.Count > 0)
+                {
+                    button.AddToClassList("build-option--spaced");
+                }
                 _buildMenu.Add(button);
                 _buildOptionButtons.Add(button);
                 _buildOptionLookup[button] = option;

--- a/Assets/UI/USS/HUD.uss
+++ b/Assets/UI/USS/HUD.uss
@@ -9,7 +9,7 @@
     border-radius: 6px;
 }
 
-.root > * + * {
+.stacked {
     margin-top: 4px;
 }
 
@@ -27,14 +27,12 @@
     justify-content: space-between;
 }
 
-.time-controls button + button,
-.save-controls button + button {
-    margin-left: 4px;
+.hud-button {
+    flex-grow: 1;
 }
 
-.time-controls button,
-.save-controls button {
-    flex-grow: 1;
+.hud-button--spaced {
+    margin-left: 4px;
 }
 
 .selection {
@@ -48,10 +46,6 @@
     flex-direction: column;
 }
 
-.build-controls > * + * {
-    margin-top: 4px;
-}
-
 .build-menu {
     background-color: rgba(255, 255, 255, 0.05);
     border-radius: 4px;
@@ -59,12 +53,12 @@
     flex-direction: column;
 }
 
-.build-menu button + button {
-    margin-top: 4px;
-}
-
 .build-option {
     justify-content: flex-start;
+}
+
+.build-option--spaced {
+    margin-top: 4px;
 }
 
 .build-option--active {

--- a/Assets/UI/UXML/HUD.uxml
+++ b/Assets/UI/UXML/HUD.uxml
@@ -2,23 +2,23 @@
 <engine:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xmlns:engine="UnityEngine.UIElements">
   <ui:VisualElement class="root">
     <ui:Label name="cashLabel" class="stat" text="Cash: 0" />
-    <ui:Label name="customerLabel" class="stat" text="Customers: 0" />
-    <ui:Label name="ordersLabel" class="stat" text="Orders" />
-    <ui:ScrollView name="ordersScroll" class="orders" />
-    <ui:VisualElement class="time-controls">
-      <ui:Button name="pauseBtn" text="Pause" />
-      <ui:Button name="play1Btn" text="1x" />
-      <ui:Button name="play2Btn" text="2x" />
-      <ui:Button name="play4Btn" text="4x" />
+    <ui:Label name="customerLabel" class="stat stacked" text="Customers: 0" />
+    <ui:Label name="ordersLabel" class="stat stacked" text="Orders" />
+    <ui:ScrollView name="ordersScroll" class="orders stacked" />
+    <ui:VisualElement class="time-controls stacked">
+      <ui:Button name="pauseBtn" class="hud-button" text="Pause" />
+      <ui:Button name="play1Btn" class="hud-button hud-button--spaced" text="1x" />
+      <ui:Button name="play2Btn" class="hud-button hud-button--spaced" text="2x" />
+      <ui:Button name="play4Btn" class="hud-button hud-button--spaced" text="4x" />
     </ui:VisualElement>
-    <ui:VisualElement class="save-controls">
-      <ui:Button name="saveBtn" text="Save (F5)" />
-      <ui:Button name="loadBtn" text="Load (F9)" />
+    <ui:VisualElement class="save-controls stacked">
+      <ui:Button name="saveBtn" class="hud-button" text="Save (F5)" />
+      <ui:Button name="loadBtn" class="hud-button hud-button--spaced" text="Load (F9)" />
     </ui:VisualElement>
-    <ui:Label name="selectionLabel" class="stat selection" text="Selecionado: Nenhum" />
-    <ui:VisualElement name="buildControls" class="build-controls">
+    <ui:Label name="selectionLabel" class="stat selection stacked" text="Selecionado: Nenhum" />
+    <ui:VisualElement name="buildControls" class="build-controls stacked">
       <ui:Button name="buildToggleBtn" text="Construir" />
-      <ui:VisualElement name="buildMenu" class="build-menu" />
+      <ui:VisualElement name="buildMenu" class="build-menu stacked" />
     </ui:VisualElement>
   </ui:VisualElement>
 </engine:UXML>


### PR DESCRIPTION
## Summary
- set the dev bootstrap PanelSettings reference resolution with a `Vector2Int`
- replace unsupported USS combinators with helper classes for HUD spacing
- update the HUD UXML and controller to use the new style classes

## Testing
- not run (Unity editor unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf4089c60483338d9f63230fa16f51