### PR TITLE
Fix agent intent labels to flip when camera sees backside

### DIFF
--- a/Assets/Agents/AgentIntentDisplay.cs
+++ b/Assets/Agents/AgentIntentDisplay.cs
@@ -44,10 +44,18 @@ namespace TavernSim.Agents
 
             var worldPosition = transform.position + offset;
             _labelTransform.position = worldPosition;
-            var toCamera = _camera.transform.position - worldPosition;
+            var cameraTransform = _camera.transform;
+            var toCamera = cameraTransform.position - worldPosition;
             if (toCamera.sqrMagnitude > Mathf.Epsilon)
             {
-                _labelTransform.rotation = Quaternion.LookRotation(toCamera, Vector3.up);
+                var rotation = Quaternion.LookRotation(toCamera, cameraTransform.up);
+                _labelTransform.rotation = rotation;
+
+                // If the label ends up aligned with the camera forward we are looking at its back.
+                if (Vector3.Dot(_labelTransform.forward, cameraTransform.forward) > 0f)
+                {
+                    _labelTransform.rotation = rotation * Quaternion.AngleAxis(180f, cameraTransform.up);
+                }
             }
         }
 

--- a/Assets/UI/HUDController.cs
+++ b/Assets/UI/HUDController.cs
@@ -100,12 +100,11 @@ namespace TavernSim.UI
             {
                 visualConfig = Resources.Load<HUDVisualConfig>("UI/HUDVisualConfig");
             }
-
-            ApplyVisualTree();
         }
 
         private void OnEnable()
         {
+            ApplyVisualTree();
             HookEvents();
         }
 
@@ -162,43 +161,49 @@ namespace TavernSim.UI
 
         private void ApplyVisualTree()
         {
-            if (visualConfig != null)
+            if (_document == null)
             {
-                if (visualConfig.VisualTree != null)
-                {
-                    _document.visualTreeAsset = visualConfig.VisualTree;
-                }
-
-                if (visualConfig.StyleSheet != null)
-                {
-                    var root = _document.rootVisualElement;
-                    if (!root.styleSheets.Contains(visualConfig.StyleSheet))
-                    {
-                        root.styleSheets.Add(visualConfig.StyleSheet);
-                    }
-                }
+                Debug.LogWarning("HUDController requires a UIDocument to build the HUD visuals.");
+                return;
             }
 
             var rootElement = _document.rootVisualElement;
-            if (_document.visualTreeAsset == null)
+            if (rootElement == null)
             {
-                rootElement.Clear();
-                var fallbackRoot = new VisualElement { style = { flexDirection = FlexDirection.Column } };
-                rootElement.Add(fallbackRoot);
-                rootElement = fallbackRoot;
+                Debug.LogWarning("HUDController could not access the UIDocument root. UI will be applied once the panel is ready.");
+                return;
             }
 
-            _controlsLabel = rootElement.Q<Label>("controlsLabel") ?? CreateLabel(rootElement, "controlsLabel", string.Empty);
+            rootElement.Clear();
+
+            VisualElement layoutRoot;
+            if (visualConfig != null && visualConfig.VisualTree != null)
+            {
+                layoutRoot = visualConfig.VisualTree.Instantiate();
+                rootElement.Add(layoutRoot);
+            }
+            else
+            {
+                layoutRoot = new VisualElement { style = { flexDirection = FlexDirection.Column } };
+                rootElement.Add(layoutRoot);
+            }
+
+            if (visualConfig != null && visualConfig.StyleSheet != null && !rootElement.styleSheets.Contains(visualConfig.StyleSheet))
+            {
+                rootElement.styleSheets.Add(visualConfig.StyleSheet);
+            }
+
+            _controlsLabel = rootElement.Q<Label>("controlsLabel") ?? CreateLabel(layoutRoot, "controlsLabel", string.Empty);
             _controlsLabel.text = GetControlsSummary();
 
-            _cashLabel = rootElement.Q<Label>("cashLabel") ?? CreateLabel(rootElement, "cashLabel", "Cash: 0");
-            _customerLabel = rootElement.Q<Label>("customerLabel") ?? CreateLabel(rootElement, "customerLabel", "Customers: 0");
-            _ordersScroll = rootElement.Q<ScrollView>("ordersScroll") ?? CreateScroll(rootElement);
-            _saveButton = rootElement.Q<Button>("saveBtn") ?? CreateButton(rootElement, "saveBtn", "Save (F5)");
-            _loadButton = rootElement.Q<Button>("loadBtn") ?? CreateButton(rootElement, "loadBtn", "Load (F9)");
-            _selectionLabel = rootElement.Q<Label>("selectionLabel") ?? CreateLabel(rootElement, "selectionLabel", "Selecionado: Nenhum");
-            _buildToggleButton = rootElement.Q<Button>("buildToggleBtn") ?? CreateButton(rootElement, "buildToggleBtn", "Construir");
-            _buildMenu = rootElement.Q<VisualElement>("buildMenu") ?? CreateBuildMenu(rootElement);
+            _cashLabel = rootElement.Q<Label>("cashLabel") ?? CreateLabel(layoutRoot, "cashLabel", "Cash: 0");
+            _customerLabel = rootElement.Q<Label>("customerLabel") ?? CreateLabel(layoutRoot, "customerLabel", "Customers: 0");
+            _ordersScroll = rootElement.Q<ScrollView>("ordersScroll") ?? CreateScroll(layoutRoot);
+            _saveButton = rootElement.Q<Button>("saveBtn") ?? CreateButton(layoutRoot, "saveBtn", "Save (F5)");
+            _loadButton = rootElement.Q<Button>("loadBtn") ?? CreateButton(layoutRoot, "loadBtn", "Load (F9)");
+            _selectionLabel = rootElement.Q<Label>("selectionLabel") ?? CreateLabel(layoutRoot, "selectionLabel", "Selecionado: Nenhum");
+            _buildToggleButton = rootElement.Q<Button>("buildToggleBtn") ?? CreateButton(layoutRoot, "buildToggleBtn", "Construir");
+            _buildMenu = rootElement.Q<VisualElement>("buildMenu") ?? CreateBuildMenu(layoutRoot);
 
             CreateBuildButtons();
             SetBuildMenuVisible(false);


### PR DESCRIPTION
## Summary
- orient agent intent labels using the active camera's up vector for stable billboarding
- flip the label 180° when the camera would otherwise view the back side so the text is never mirrored
- instantiate the DevBootstrap HUD layout manually so the overlay appears when running the dev scene

## Testing
- not run (Unity editor unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68cf47faa2e08333ad08a33a4d0ca6b8