### PR TITLE
Load runtime panel settings asset for dev bootstrap

### DIFF
--- a/Assets/Bootstrap/DevBootstrap.cs
+++ b/Assets/Bootstrap/DevBootstrap.cs
@@ -3,6 +3,7 @@ using UnityEngine.AI;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UIElements;
+using UnityEngine.TextCore.Text;
 #if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
 using UnityEngine.InputSystem.UI;
 #endif
@@ -28,7 +29,9 @@ namespace TavernSim.Bootstrap
 
         private static PanelSettings _panelSettings;
         private static ThemeStyleSheet _panelTheme;
+        private static TextSettings _textSettings;
         private static bool _themeLookupAttempted;
+        private static bool _textSettingsLookupAttempted;
 
         private SimulationRunner _runner;
         private EconomySystem _economySystem;
@@ -272,18 +275,34 @@ namespace TavernSim.Bootstrap
                 return _panelSettings;
             }
 
-            _panelSettings = ScriptableObject.CreateInstance<PanelSettings>();
-            _panelSettings.name = "DevBootstrapPanelSettings";
-            _panelSettings.hideFlags = HideFlags.HideAndDontSave;
-            _panelSettings.scaleMode = PanelScaleMode.ScaleWithScreenSize;
-            _panelSettings.referenceResolution = new Vector2Int(1920, 1080);
-            _panelSettings.sortingOrder = 100;
-            _panelSettings.targetTexture = null;
+            var asset = Resources.Load<PanelSettings>(PanelSettingsResourcePath);
+            if (asset != null)
+            {
+                _panelSettings = Instantiate(asset);
+                _panelSettings.name = asset.name + " (Runtime)";
+                _panelSettings.hideFlags = HideFlags.HideAndDontSave;
+            }
+            else
+            {
+                _panelSettings = ScriptableObject.CreateInstance<PanelSettings>();
+                _panelSettings.name = "DevBootstrapPanelSettings";
+                _panelSettings.hideFlags = HideFlags.HideAndDontSave;
+                _panelSettings.scaleMode = PanelScaleMode.ScaleWithScreenSize;
+                _panelSettings.referenceResolution = new Vector2Int(1920, 1080);
+                _panelSettings.sortingOrder = 100;
+                _panelSettings.targetTexture = null;
+            }
 
             var theme = GetOrLoadTheme();
             if (theme != null)
             {
                 _panelSettings.themeStyleSheet = theme;
+            }
+
+            var textSettings = GetOrLoadTextSettings();
+            if (textSettings != null)
+            {
+                _panelSettings.textSettings = textSettings;
             }
 
             return _panelSettings;
@@ -298,29 +317,37 @@ namespace TavernSim.Bootstrap
 
             _themeLookupAttempted = true;
 
-            foreach (var path in DefaultThemeResourcePaths)
-            {
-                var theme = Resources.Load<ThemeStyleSheet>(path);
-                if (theme != null)
-                {
-                    _panelTheme = theme;
-                    break;
-                }
-            }
+            _panelTheme = Resources.Load<ThemeStyleSheet>(ThemeResourcePath);
 
             if (_panelTheme == null)
             {
-                Debug.LogWarning("DevBootstrap could not locate a UI Toolkit ThemeStyleSheet. HUD will use default styling.");
+                Debug.LogWarning("DevBootstrap could not locate the runtime UI theme. HUD will use default styling.");
             }
 
             return _panelTheme;
         }
 
-        private static readonly string[] DefaultThemeResourcePaths =
+        private static TextSettings GetOrLoadTextSettings()
         {
-            "ThemeSettings/DefaultCommonLight",
-            "ThemeSettings/DefaultCommonDark",
-            "ThemeSettings/DefaultCommon"
-        };
+            if (_textSettings != null || _textSettingsLookupAttempted)
+            {
+                return _textSettings;
+            }
+
+            _textSettingsLookupAttempted = true;
+
+            _textSettings = Resources.Load<TextSettings>(TextSettingsResourcePath);
+
+            if (_textSettings == null)
+            {
+                Debug.LogWarning("DevBootstrap could not locate default TextSettings. UI text may use fallback fonts.");
+            }
+
+            return _textSettings;
+        }
+
+        private const string PanelSettingsResourcePath = "UI Toolkit/DevBootstrapPanelSettings";
+        private const string ThemeResourcePath = "UI Toolkit/UnityThemes/UnityDefaultRuntimeTheme";
+        private const string TextSettingsResourcePath = "UI Toolkit/Default UITK Text Settings";
     }
 }

--- a/Assets/Resources/UI Toolkit.meta
+++ b/Assets/Resources/UI Toolkit.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b27fb3125277f4799ab1ff75934bcc0e
+guid: 77916da266ea445f0a196be2457a8eb4
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Resources/UI Toolkit/Default UITK Text Settings.asset
+++ b/Assets/Resources/UI Toolkit/Default UITK Text Settings.asset
@@ -1,0 +1,35 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 83edbd52c03fc4d319804b472b97f952, type: 3}
+  m_Name: Default UITK Text Settings
+  m_EditorClassIdentifier: 
+  m_Version: 
+  m_DefaultFontAsset: {fileID: 11400000, guid: 11620d32377004149ba4922e54514328, type: 2}
+  m_DefaultFontAssetPath: Fonts & Materials/
+  m_FallbackFontAssets: []
+  m_MatchMaterialPreset: 0
+  m_MissingCharacterUnicode: 0
+  m_DefaultSpriteAsset: {fileID: 11400000, guid: 31e137292bb444d66940d42d0014a46d,
+    type: 2}
+  m_DefaultSpriteAssetPath: Sprite Assets/
+  m_FallbackSpriteAssets: []
+  m_MissingSpriteCharacterUnicode: 0
+  m_DefaultStyleSheet: {fileID: 11400000, guid: 2f0003373d49e4ce899eacc28d3db6ae,
+    type: 2}
+  m_StyleSheetsResourcePath: Text Style Sheets/
+  m_DefaultColorGradientPresetsPath: Text Color Gradients/
+  m_UnicodeLineBreakingRules:
+    m_UnicodeLineBreakingRules: {fileID: 0}
+    m_LeadingCharacters: {fileID: 0}
+    m_FollowingCharacters: {fileID: 0}
+    m_UseModernHangulLineBreakingRules: 0
+  m_DisplayWarnings: 0

--- a/Assets/Resources/UI Toolkit/Default UITK Text Settings.asset.meta
+++ b/Assets/Resources/UI Toolkit/Default UITK Text Settings.asset.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: b27fb3125277f4799ab1ff75934bcc0e
-folderAsset: yes
-DefaultImporter:
+guid: fb48f3b3eecb047e88a6667306380d19
+NativeFormatImporter:
   externalObjects: {}
+  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Resources/UI Toolkit/DevBootstrapPanelSettings.asset
+++ b/Assets/Resources/UI Toolkit/DevBootstrapPanelSettings.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 782f629a2df6243629ea8fe2873666a4, type: 3}
+  m_Name: DevBootstrapPanelSettings
+  m_EditorClassIdentifier: 
+  themeUss: {fileID: -4733365628477956816, guid: d759aaabe9049443383e8baa60184657,
+    type: 3}
+  m_TargetTexture: {fileID: 0}
+  m_ScaleMode: 1
+  m_Scale: 1
+  m_ReferenceDpi: 96
+  m_FallbackDpi: 96
+  m_ReferenceResolution: {x: 1920, y: 1080}
+  m_ScreenMatchMode: 1
+  m_Match: 0.5
+  m_SortingOrder: 100
+  m_TargetDisplay: 0
+  m_ClearDepthStencil: 1
+  m_ClearColor: 0
+  m_ColorClearValue: {r: 0, g: 0, b: 0, a: 0}
+  m_DynamicAtlasSettings:
+    m_MinAtlasSize: 64
+    m_MaxAtlasSize: 4096
+    m_MaxSubTextureSize: 64
+    m_ActiveFilters: 31
+  m_AtlasBlitShader: {fileID: 4800000, guid: 662b00f569c02f84bbc426d4c41ceb5e, type: 3}
+  m_RuntimeShader: {fileID: 4800000, guid: 1e5f18a346ed454418f93aa7eaf55791, type: 3}
+  m_RuntimeWorldShader: {fileID: 4800000, guid: 7082954141e3ccc43bc3b217cf12e2e0,
+    type: 3}
+  textSettings: {fileID: 11400000, guid: fb48f3b3eecb047e88a6667306380d19, type: 2}

--- a/Assets/Resources/UI Toolkit/DevBootstrapPanelSettings.asset.meta
+++ b/Assets/Resources/UI Toolkit/DevBootstrapPanelSettings.asset.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: b27fb3125277f4799ab1ff75934bcc0e
-folderAsset: yes
-DefaultImporter:
+guid: 5adb043d2f1ac664f95f8ebd985208c5
+NativeFormatImporter:
   externalObjects: {}
+  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Resources/UI Toolkit/Resources.meta
+++ b/Assets/Resources/UI Toolkit/Resources.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b27fb3125277f4799ab1ff75934bcc0e
+guid: bfe44570f971148ce881fb1460793e4c
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Resources/UI Toolkit/Resources/Fonts & Materials.meta
+++ b/Assets/Resources/UI Toolkit/Resources/Fonts & Materials.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b27fb3125277f4799ab1ff75934bcc0e
+guid: 50eb98bd85d284233a0cd6afd6e976b4
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Resources/UI Toolkit/Resources/Fonts & Materials/LiberationSans SDF.asset
+++ b/Assets/Resources/UI Toolkit/Resources/Fonts & Materials/LiberationSans SDF.asset
@@ -1,0 +1,249 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9a8fdda5b4c5f6544bbac8a17c59089c, type: 3}
+  m_Name: LiberationSans SDF
+  m_EditorClassIdentifier: 
+  m_Version: 1.1.0
+  m_Material: {fileID: 4683684913593235938}
+  m_SourceFontFileGUID: 189c84d4bdcba6d449b66c25aad92981
+  m_SourceFontFile_EditorRef: {fileID: 12800000, guid: 189c84d4bdcba6d449b66c25aad92981,
+    type: 3}
+  m_SourceFontFile: {fileID: 12800000, guid: 189c84d4bdcba6d449b66c25aad92981, type: 3}
+  m_AtlasPopulationMode: 1
+  m_FaceInfo:
+    m_FamilyName: Liberation Sans
+    m_StyleName: Regular
+    m_PointSize: 90
+    m_Scale: 1
+    m_LineHeight: 103.49121
+    m_AscentLine: 81.47461
+    m_CapLine: 62
+    m_MeanLine: 48
+    m_Baseline: 0
+    m_DescentLine: -19.072266
+    m_SuperscriptOffset: 81.47461
+    m_SuperscriptSize: 0.5
+    m_SubscriptOffset: -19.072266
+    m_SubscriptSize: 0.5
+    m_UnderlineOffset: -12.832031
+    m_UnderlineThickness: 6.591797
+    m_StrikethroughOffset: 19.2
+    m_StrikethroughThickness: 6.591797
+    m_TabWidth: 25
+  m_FontWeightTable:
+  - regularTypeface: {fileID: 0}
+    italicTypeface: {fileID: 0}
+  - regularTypeface: {fileID: 0}
+    italicTypeface: {fileID: 0}
+  - regularTypeface: {fileID: 0}
+    italicTypeface: {fileID: 0}
+  - regularTypeface: {fileID: 0}
+    italicTypeface: {fileID: 0}
+  - regularTypeface: {fileID: 0}
+    italicTypeface: {fileID: 0}
+  - regularTypeface: {fileID: 0}
+    italicTypeface: {fileID: 0}
+  - regularTypeface: {fileID: 0}
+    italicTypeface: {fileID: 0}
+  - regularTypeface: {fileID: 0}
+    italicTypeface: {fileID: 0}
+  - regularTypeface: {fileID: 0}
+    italicTypeface: {fileID: 0}
+  - regularTypeface: {fileID: 0}
+    italicTypeface: {fileID: 0}
+  m_GlyphTable: []
+  m_CharacterTable: []
+  m_AtlasTextures:
+  - {fileID: 1846935173530049853}
+  m_AtlasTextureIndex: 0
+  m_IsMultiAtlasTexturesEnabled: 1
+  m_ClearDynamicDataOnBuild: 1
+  m_AtlasWidth: 1024
+  m_AtlasHeight: 1024
+  m_AtlasPadding: 9
+  m_AtlasRenderMode: 4165
+  m_UsedGlyphRects: []
+  m_FreeGlyphRects:
+  - m_X: 0
+    m_Y: 0
+    m_Width: 1023
+    m_Height: 1023
+  m_FontFeatureTable:
+    m_GlyphPairAdjustmentRecords: []
+  m_FallbackFontAssetTable: []
+  m_fontAssetCreationEditorSettings:
+    sourceFontFileGUID: 189c84d4bdcba6d449b66c25aad92981
+    pointSizeSamplingMode: 0
+    pointSize: 90
+    padding: 9
+    packingMode: 0
+    atlasWidth: 1024
+    atlasHeight: 1024
+    characterSetSelectionMode: 7
+    characterSequence: 
+    referencedFontAssetGUID: 
+    referencedTextAssetGUID: 
+    fontStyle: 0
+    fontStyleModifier: 0
+    renderMode: 4165
+    includeFontFeatures: 0
+  m_RegularStyleWeight: 0
+  m_RegularStyleSpacing: 0
+  m_BoldStyleWeight: 0.75
+  m_BoldStyleSpacing: 7
+  m_ItalicStyleSlant: 35
+  m_TabMultiple: 10
+  m_fontInfo:
+    Name: 
+    PointSize: 0
+    Scale: 0
+    CharacterCount: 0
+    LineHeight: 0
+    Baseline: 0
+    Ascender: 0
+    CapHeight: 0
+    Descender: 0
+    CenterLine: 0
+    SuperscriptOffset: 0
+    SubscriptOffset: 0
+    SubSize: 0
+    Underline: 0
+    UnderlineThickness: 0
+    strikethrough: 0
+    strikethroughThickness: 0
+    TabWidth: 0
+    Padding: 0
+    AtlasWidth: 0
+    AtlasHeight: 0
+  fontWeights: []
+  atlas: {fileID: 0}
+  m_glyphInfoList: []
+  fallbackFontAssets: []
+  m_KerningTable:
+    kerningPairs: []
+--- !u!28 &1846935173530049853
+Texture2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: LiberationSans Atlas
+  m_ImageContentsHash:
+    serializedVersion: 2
+    Hash: 00000000000000000000000000000000
+  m_ForcedFallbackFormat: 4
+  m_DownscaleFallback: 0
+  m_IsAlphaChannelOptional: 0
+  serializedVersion: 2
+  m_Width: 0
+  m_Height: 0
+  m_CompleteImageSize: 0
+  m_MipsStripped: 0
+  m_TextureFormat: 1
+  m_MipCount: 1
+  m_IsReadable: 1
+  m_IsPreProcessed: 0
+  m_IgnoreMasterTextureLimit: 0
+  m_StreamingMipmaps: 0
+  m_StreamingMipmapsPriority: 0
+  m_VTOnly: 0
+  m_AlphaIsTransparency: 0
+  m_ImageCount: 1
+  m_TextureDimension: 2
+  m_TextureSettings:
+    serializedVersion: 2
+    m_FilterMode: 1
+    m_Aniso: 1
+    m_MipBias: 0
+    m_WrapU: 0
+    m_WrapV: 0
+    m_WrapW: 0
+  m_LightmapFormat: 0
+  m_ColorSpace: 0
+  m_PlatformBlob: 
+  image data: 0
+  _typelessdata: 
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
+--- !u!21 &4683684913593235938
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: LiberationSans Atlas Material
+  m_Shader: {fileID: 4800000, guid: 62b6d79d475fb5147ab93c75dede1914, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 1846935173530049853}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MaskTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _CullMode: 0
+    - _FaceDilate: 0
+    - _GradientScale: 10
+    - _MaskEdgeSoftness: 0.01
+    - _MaskInverse: 0
+    - _MaskSoftnessX: 0
+    - _MaskSoftnessY: 0
+    - _MaskWipeControl: 0.5
+    - _OutlineSoftness: 0
+    - _OutlineWidth: 0
+    - _PerspectiveFilter: 0.875
+    - _ScaleRatioA: 1
+    - _ScaleRatioB: 1
+    - _ScaleRatioC: 1
+    - _ScaleX: 1
+    - _ScaleY: 1
+    - _ShaderFlags: 0
+    - _Sharpness: 0
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _TextureHeight: 1024
+    - _TextureWidth: 1024
+    - _UnderlayDilate: 0
+    - _UnderlayOffsetX: 0
+    - _UnderlayOffsetY: 0
+    - _UnderlaySoftness: 0
+    - _VertexOffsetX: 0
+    - _VertexOffsetY: 0
+    - _WeightBold: 0.75
+    - _WeightNormal: 0
+    m_Colors:
+    - _ClipRect: {r: -32767, g: -32767, b: 32767, a: 32767}
+    - _FaceColor: {r: 1, g: 1, b: 1, a: 1}
+    - _MaskEdgeColor: {r: 1, g: 1, b: 1, a: 1}
+    - _OutlineColor: {r: 0, g: 0, b: 0, a: 1}
+    - _UnderlayColor: {r: 0, g: 0, b: 0, a: 0.5}
+  m_BuildTextureStacks: []

--- a/Assets/Resources/UI Toolkit/Resources/Fonts & Materials/LiberationSans SDF.asset.meta
+++ b/Assets/Resources/UI Toolkit/Resources/Fonts & Materials/LiberationSans SDF.asset.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: b27fb3125277f4799ab1ff75934bcc0e
-folderAsset: yes
-DefaultImporter:
+guid: 11620d32377004149ba4922e54514328
+NativeFormatImporter:
   externalObjects: {}
+  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Resources/UI Toolkit/Resources/Sprite Assets.meta
+++ b/Assets/Resources/UI Toolkit/Resources/Sprite Assets.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b27fb3125277f4799ab1ff75934bcc0e
+guid: 737b78e595ac743c0b774f9444c60c24
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Resources/UI Toolkit/Resources/Sprite Assets/EmojiOne.asset
+++ b/Assets/Resources/UI Toolkit/Resources/Sprite Assets/EmojiOne.asset
@@ -1,0 +1,393 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &-6201156369178609850
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Text/Sprite
+  m_Shader: {fileID: 4800000, guid: 79cba8fa59e60f348930506622423d32, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 2800000, guid: dffef66376be4fa480fb02b19edbe903, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _CullMode: 0
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _ClipRect: {r: -32767, g: -32767, b: 32767, a: 32767}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 39b57e6027b777d419a52a4b7aebe947, type: 3}
+  m_Name: EmojiOne
+  m_EditorClassIdentifier: 
+  m_Version: 1.1.0
+  m_Material: {fileID: -6201156369178609850}
+  m_FaceInfo:
+    m_FamilyName: 
+    m_StyleName: 
+    m_PointSize: 0
+    m_Scale: 0
+    m_LineHeight: 0
+    m_AscentLine: 0
+    m_CapLine: 0
+    m_MeanLine: 0
+    m_Baseline: 0
+    m_DescentLine: 0
+    m_SuperscriptOffset: 0
+    m_SuperscriptSize: 0
+    m_SubscriptOffset: 0
+    m_SubscriptSize: 0
+    m_UnderlineOffset: 0
+    m_UnderlineThickness: 0
+    m_StrikethroughOffset: 0
+    m_StrikethroughThickness: 0
+    m_TabWidth: 0
+  m_SpriteAtlasTexture: {fileID: 2800000, guid: dffef66376be4fa480fb02b19edbe903,
+    type: 3}
+  m_SpriteCharacterTable:
+  - m_ElementType: 2
+    m_Unicode: 1213730
+    m_GlyphIndex: 0
+    m_Scale: 1
+    m_Name: Smiling face with smiling eyes
+    m_HashCode: -864682231
+  - m_ElementType: 2
+    m_Unicode: 1213731
+    m_GlyphIndex: 1
+    m_Scale: 1
+    m_Name: 1f60b
+    m_HashCode: 55966387
+  - m_ElementType: 2
+    m_Unicode: 1213733
+    m_GlyphIndex: 2
+    m_Scale: 1
+    m_Name: 1f60d
+    m_HashCode: 55966389
+  - m_ElementType: 2
+    m_Unicode: 1213734
+    m_GlyphIndex: 3
+    m_Scale: 1
+    m_Name: 1f60e
+    m_HashCode: 55966388
+  - m_ElementType: 2
+    m_Unicode: 1213714
+    m_GlyphIndex: 4
+    m_Scale: 1
+    m_Name: Grinning face
+    m_HashCode: -258056291
+  - m_ElementType: 2
+    m_Unicode: 1213715
+    m_GlyphIndex: 5
+    m_Scale: 1
+    m_Name: 1f601
+    m_HashCode: 55966400
+  - m_ElementType: 2
+    m_Unicode: 1213716
+    m_GlyphIndex: 6
+    m_Scale: 1
+    m_Name: Face with tears of joy
+    m_HashCode: -2012591225
+  - m_ElementType: 2
+    m_Unicode: 1213717
+    m_GlyphIndex: 7
+    m_Scale: 1
+    m_Name: 1f603
+    m_HashCode: 55966402
+  - m_ElementType: 2
+    m_Unicode: 1213718
+    m_GlyphIndex: 8
+    m_Scale: 1
+    m_Name: 1f604
+    m_HashCode: 55966405
+  - m_ElementType: 2
+    m_Unicode: 1213719
+    m_GlyphIndex: 9
+    m_Scale: 1
+    m_Name: 1f605
+    m_HashCode: 55966404
+  - m_ElementType: 2
+    m_Unicode: 1213720
+    m_GlyphIndex: 10
+    m_Scale: 1
+    m_Name: 1f606
+    m_HashCode: 55966407
+  - m_ElementType: 2
+    m_Unicode: 1213729
+    m_GlyphIndex: 11
+    m_Scale: 1
+    m_Name: 1f609
+    m_HashCode: 55966408
+  - m_ElementType: 2
+    m_Unicode: 0
+    m_GlyphIndex: 12
+    m_Scale: 1
+    m_Name: .notdef
+    m_HashCode: 612146780
+  - m_ElementType: 2
+    m_Unicode: 1217301
+    m_GlyphIndex: 13
+    m_Scale: 1
+    m_Name: 1f923
+    m_HashCode: 55982607
+  - m_ElementType: 2
+    m_Unicode: 38790
+    m_GlyphIndex: 14
+    m_Scale: 1
+    m_Name: 263a
+    m_HashCode: 1748374
+  m_SpriteGlyphTable:
+  - m_Index: 0
+    m_Metrics:
+      m_Width: 128
+      m_Height: 128
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 115.6
+      m_HorizontalAdvance: 128
+    m_GlyphRect:
+      m_X: 0
+      m_Y: 384
+      m_Width: 128
+      m_Height: 128
+    m_Scale: 1
+    m_AtlasIndex: 0
+    sprite: {fileID: 21300000, guid: dffef66376be4fa480fb02b19edbe903, type: 3}
+  - m_Index: 1
+    m_Metrics:
+      m_Width: 128
+      m_Height: 128
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 115.6
+      m_HorizontalAdvance: 128
+    m_GlyphRect:
+      m_X: 128
+      m_Y: 384
+      m_Width: 128
+      m_Height: 128
+    m_Scale: 1
+    m_AtlasIndex: 0
+    sprite: {fileID: 21300002, guid: dffef66376be4fa480fb02b19edbe903, type: 3}
+  - m_Index: 2
+    m_Metrics:
+      m_Width: 128
+      m_Height: 128
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 115.6
+      m_HorizontalAdvance: 128
+    m_GlyphRect:
+      m_X: 256
+      m_Y: 384
+      m_Width: 128
+      m_Height: 128
+    m_Scale: 1
+    m_AtlasIndex: 0
+    sprite: {fileID: 21300004, guid: dffef66376be4fa480fb02b19edbe903, type: 3}
+  - m_Index: 3
+    m_Metrics:
+      m_Width: 128
+      m_Height: 128
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 115.6
+      m_HorizontalAdvance: 128
+    m_GlyphRect:
+      m_X: 384
+      m_Y: 384
+      m_Width: 128
+      m_Height: 128
+    m_Scale: 1
+    m_AtlasIndex: 0
+    sprite: {fileID: 21300006, guid: dffef66376be4fa480fb02b19edbe903, type: 3}
+  - m_Index: 4
+    m_Metrics:
+      m_Width: 128
+      m_Height: 128
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 115.6
+      m_HorizontalAdvance: 128
+    m_GlyphRect:
+      m_X: 0
+      m_Y: 256
+      m_Width: 128
+      m_Height: 128
+    m_Scale: 1
+    m_AtlasIndex: 0
+    sprite: {fileID: 21300008, guid: dffef66376be4fa480fb02b19edbe903, type: 3}
+  - m_Index: 5
+    m_Metrics:
+      m_Width: 128
+      m_Height: 128
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 115.6
+      m_HorizontalAdvance: 128
+    m_GlyphRect:
+      m_X: 128
+      m_Y: 256
+      m_Width: 128
+      m_Height: 128
+    m_Scale: 1
+    m_AtlasIndex: 0
+    sprite: {fileID: 21300028, guid: dffef66376be4fa480fb02b19edbe903, type: 3}
+  - m_Index: 6
+    m_Metrics:
+      m_Width: 128
+      m_Height: 128
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 115.6
+      m_HorizontalAdvance: 128
+    m_GlyphRect:
+      m_X: 256
+      m_Y: 256
+      m_Width: 128
+      m_Height: 128
+    m_Scale: 1
+    m_AtlasIndex: 0
+    sprite: {fileID: 21300010, guid: dffef66376be4fa480fb02b19edbe903, type: 3}
+  - m_Index: 7
+    m_Metrics:
+      m_Width: 128
+      m_Height: 128
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 115.6
+      m_HorizontalAdvance: 128
+    m_GlyphRect:
+      m_X: 384
+      m_Y: 256
+      m_Width: 128
+      m_Height: 128
+    m_Scale: 1
+    m_AtlasIndex: 0
+    sprite: {fileID: 21300012, guid: dffef66376be4fa480fb02b19edbe903, type: 3}
+  - m_Index: 8
+    m_Metrics:
+      m_Width: 128
+      m_Height: 128
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 115.6
+      m_HorizontalAdvance: 128
+    m_GlyphRect:
+      m_X: 0
+      m_Y: 128
+      m_Width: 128
+      m_Height: 128
+    m_Scale: 1
+    m_AtlasIndex: 0
+    sprite: {fileID: 21300014, guid: dffef66376be4fa480fb02b19edbe903, type: 3}
+  - m_Index: 9
+    m_Metrics:
+      m_Width: 128
+      m_Height: 128
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 115.6
+      m_HorizontalAdvance: 128
+    m_GlyphRect:
+      m_X: 128
+      m_Y: 128
+      m_Width: 128
+      m_Height: 128
+    m_Scale: 1
+    m_AtlasIndex: 0
+    sprite: {fileID: 21300016, guid: dffef66376be4fa480fb02b19edbe903, type: 3}
+  - m_Index: 10
+    m_Metrics:
+      m_Width: 128
+      m_Height: 128
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 115.6
+      m_HorizontalAdvance: 128
+    m_GlyphRect:
+      m_X: 256
+      m_Y: 128
+      m_Width: 128
+      m_Height: 128
+    m_Scale: 1
+    m_AtlasIndex: 0
+    sprite: {fileID: 21300018, guid: dffef66376be4fa480fb02b19edbe903, type: 3}
+  - m_Index: 11
+    m_Metrics:
+      m_Width: 128
+      m_Height: 128
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 115.6
+      m_HorizontalAdvance: 128
+    m_GlyphRect:
+      m_X: 384
+      m_Y: 128
+      m_Width: 128
+      m_Height: 128
+    m_Scale: 1
+    m_AtlasIndex: 0
+    sprite: {fileID: 21300020, guid: dffef66376be4fa480fb02b19edbe903, type: 3}
+  - m_Index: 12
+    m_Metrics:
+      m_Width: 128
+      m_Height: 128
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 115.6
+      m_HorizontalAdvance: 128
+    m_GlyphRect:
+      m_X: 0
+      m_Y: 0
+      m_Width: 128
+      m_Height: 128
+    m_Scale: 1
+    m_AtlasIndex: 0
+    sprite: {fileID: 21300022, guid: dffef66376be4fa480fb02b19edbe903, type: 3}
+  - m_Index: 13
+    m_Metrics:
+      m_Width: 128
+      m_Height: 128
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 115.6
+      m_HorizontalAdvance: 128
+    m_GlyphRect:
+      m_X: 128
+      m_Y: 0
+      m_Width: 128
+      m_Height: 128
+    m_Scale: 1
+    m_AtlasIndex: 0
+    sprite: {fileID: 21300024, guid: dffef66376be4fa480fb02b19edbe903, type: 3}
+  - m_Index: 14
+    m_Metrics:
+      m_Width: 128
+      m_Height: 128
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 115.6
+      m_HorizontalAdvance: 128
+    m_GlyphRect:
+      m_X: 256
+      m_Y: 0
+      m_Width: 128
+      m_Height: 128
+    m_Scale: 1
+    m_AtlasIndex: 0
+    sprite: {fileID: 21300026, guid: dffef66376be4fa480fb02b19edbe903, type: 3}
+  fallbackSpriteAssets: []

--- a/Assets/Resources/UI Toolkit/Resources/Sprite Assets/EmojiOne.asset.meta
+++ b/Assets/Resources/UI Toolkit/Resources/Sprite Assets/EmojiOne.asset.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: b27fb3125277f4799ab1ff75934bcc0e
-folderAsset: yes
-DefaultImporter:
+guid: 31e137292bb444d66940d42d0014a46d
+NativeFormatImporter:
   externalObjects: {}
+  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Resources/UI Toolkit/Resources/Text StyleSheets.meta
+++ b/Assets/Resources/UI Toolkit/Resources/Text StyleSheets.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b27fb3125277f4799ab1ff75934bcc0e
+guid: bc586f24df4984142be205f486f6b2e7
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Resources/UI Toolkit/Resources/Text StyleSheets/Text StyleSheet.asset
+++ b/Assets/Resources/UI Toolkit/Resources/Text StyleSheets/Text StyleSheet.asset
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59db50dea4e43b042ba63605012274c8, type: 3}
+  m_Name: Text StyleSheet
+  m_EditorClassIdentifier: 
+  m_StyleList:
+  - m_Name: Normal
+    m_HashCode: -1183493901
+    m_OpeningDefinition: 
+    m_ClosingDefinition: 
+    m_OpeningTagArray: 
+    m_ClosingTagArray: 
+    m_OpeningTagUnicodeArray: 
+    m_ClosingTagUnicodeArray: 
+  - m_Name: Link
+    m_HashCode: 2656128
+    m_OpeningDefinition: <color=#0000FF><u>
+    m_ClosingDefinition: </u></color>
+    m_OpeningTagArray: 3c000000630000006f0000006c0000006f000000720000003d000000230000003000000030000000300000003000000046000000460000003e0000003c000000750000003e000000
+    m_ClosingTagArray: 3c0000002f000000750000003e0000003c0000002f000000630000006f0000006c0000006f000000720000003e000000
+    m_OpeningTagUnicodeArray: 3c000000630000006f0000006c0000006f000000720000003d000000230000003000000030000000300000003000000046000000460000003e0000003c000000750000003e000000
+    m_ClosingTagUnicodeArray: 3c0000002f000000750000003e0000003c0000002f000000630000006f0000006c0000006f000000720000003e000000

--- a/Assets/Resources/UI Toolkit/Resources/Text StyleSheets/Text StyleSheet.asset.meta
+++ b/Assets/Resources/UI Toolkit/Resources/Text StyleSheets/Text StyleSheet.asset.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: b27fb3125277f4799ab1ff75934bcc0e
-folderAsset: yes
-DefaultImporter:
+guid: 2f0003373d49e4ce899eacc28d3db6ae
+NativeFormatImporter:
   externalObjects: {}
+  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Resources/UI Toolkit/UnityThemes.meta
+++ b/Assets/Resources/UI Toolkit/UnityThemes.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b27fb3125277f4799ab1ff75934bcc0e
+guid: 34dce80d98f7e49cb80983bdfedd9369
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Resources/UI Toolkit/UnityThemes/UnityDefaultRuntimeTheme.tss
+++ b/Assets/Resources/UI Toolkit/UnityThemes/UnityDefaultRuntimeTheme.tss
@@ -1,0 +1,1 @@
+@import url("unity-theme://default");

--- a/Assets/Resources/UI Toolkit/UnityThemes/UnityDefaultRuntimeTheme.tss.meta
+++ b/Assets/Resources/UI Toolkit/UnityThemes/UnityDefaultRuntimeTheme.tss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d759aaabe9049443383e8baa60184657
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12388, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0


### PR DESCRIPTION
## Summary
- load a PanelSettings ScriptableObject from Resources so the dev bootstrap HUD uses a proper UI Toolkit configuration
- bundle Unity's default runtime UI theme and text settings assets (copied from the Unity Royale runtime sample) under Resources for consistent styling
- fall back to generated settings while logging clear warnings when the assets are missing

## Testing
- not run (Unity editor unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf6152395883338b584d79ef7b2cc5