### PR TITLE
Fix event namespace compatibility and guard tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,26 @@ and Codex assistance stay aligned.
 - Use assembly definition files to isolate systems and tests; hook up references (including package assemblies such as
   `Unity.AI.Navigation`) explicitly when creating new modules.
 
+### HUD menu & toast system
+- The runtime HUD now instantiates a `MenuController` (UI Toolkit) that exposes a foldout with toggles for every `RecipeSO` in the
+  `Catalog`. The component implements `IMenuPolicy` and persists toggle state via `PlayerPrefs` using the recipe id as the key.
+  `AgentSystem.SetMenuPolicy` must be called during bootstrap (see `DevBootstrap`) so waiters can respect menu restrictions
+  before submitting orders.
+- `HudToastController` subscribes to the shared `GameEventBus` and renders temporary toast notifications at the bottom-left of the
+  HUD. Gameplay systems publish events through the `IEventBus` (either by injecting `GameEventBus` or by calling
+  `HUDController.PublishEvent`). Core events include menu blocks, missing ingredients, customer anger, and order readiness/delivery.
+- When creating new systems that need to notify the player, prefer publishing `GameEvent` instances rather than logging directly.
+  The bootstrap scene wires everything together; other scenes must inject the event bus into `OrderSystem`, `AgentSystem`, and the
+  HUD components to enable the experience.
+
+### Build & staffing controls
+- The build menu in the HUD now exposes toggles for kitchen stations, bar counters, and pickup point markers alongside the table
+  and decoration props. The `GridPlacer` handles these new `PlaceableKind` entries by spawning simple graybox meshes and marking
+  the appropriate NavMesh obstacles so pathing remains valid.
+- Runtime HUD controls include "Contratar garçom" and "Contratar cozinheiro" buttons. Each click spawns a new NavMesh-agent
+  backed capsule; waiters are automatically registered with `AgentSystem`, which keeps customer assignments unique across
+  multiple staffers.
+
 ## Continuous integration
 - Pull requests must keep the GitHub Actions workflow green. The pipeline contains two jobs:
   - **Tests** – `game-ci/unity-test-runner@v4` runs EditMode + PlayMode tests against Unity 2022.3.62f1.

--- a/Assets/Agents/Bartender.cs
+++ b/Assets/Agents/Bartender.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+using UnityEngine.AI;
+
+namespace TavernSim.Agents
+{
+    [RequireComponent(typeof(NavMeshAgent))]
+    public sealed class Bartender : MonoBehaviour
+    {
+        public NavMeshAgent Agent { get; private set; }
+
+        private void Awake()
+        {
+            Agent = GetComponent<NavMeshAgent>();
+            Agent.angularSpeed = 720f;
+            Agent.acceleration = 24f;
+            Agent.stoppingDistance = 0.05f;
+        }
+    }
+}

--- a/Assets/Agents/Bartender.cs.meta
+++ b/Assets/Agents/Bartender.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 12085c27-ff01-4671-8eab-7ef80e66ef54
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Agents/Cook.cs
+++ b/Assets/Agents/Cook.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+using UnityEngine.AI;
+
+namespace TavernSim.Agents
+{
+    [RequireComponent(typeof(NavMeshAgent))]
+    public sealed class Cook : MonoBehaviour
+    {
+        public NavMeshAgent Agent { get; private set; }
+
+        private void Awake()
+        {
+            Agent = GetComponent<NavMeshAgent>();
+            Agent.angularSpeed = 600f;
+            Agent.acceleration = 20f;
+            Agent.stoppingDistance = 0.05f;
+        }
+    }
+}

--- a/Assets/Agents/Cook.cs.meta
+++ b/Assets/Agents/Cook.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e0efc7db-d0ab-44cf-8ffe-60c14319f3e9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Bootstrap/DevBootstrap.cs
+++ b/Assets/Bootstrap/DevBootstrap.cs
@@ -47,10 +47,28 @@ namespace TavernSim.Bootstrap
         private TimeControls _timeControls;
         private GridPlacer _gridPlacer;
         private SelectionService _selectionService;
+        private GameEventBus _eventBus;
+        private IInventoryService _inventoryService;
+        private MenuController _menuController;
+        private HudToastController _toastController;
+
+        private Waiter _initialWaiter;
+        private Cook _initialCook;
+        private Bartender _initialBartender;
+        private int _waiterCount;
+        private int _cookCount;
+        private int _bartenderCount;
 
         private Vector3 _entryPoint;
         private Vector3 _exitPoint;
         private Vector3 _kitchenPoint;
+        private Vector3 _kitchenPickupPoint;
+        private Vector3 _barPickupPoint;
+
+        private static readonly Vector3 WaiterSpawnBase = new Vector3(-1f, 0f, 0f);
+        private static readonly Vector3 CookSpawnBase = new Vector3(-1.5f, 0f, 2.6f);
+        private static readonly Vector3 BartenderSpawnBase = new Vector3(-2.5f, 0f, 1.5f);
+        private const float StaffSpawnSpacing = 0.75f;
 
         public EconomySystem Economy => _economySystem;
         public OrderSystem Orders => _orderSystem;
@@ -90,6 +108,16 @@ namespace TavernSim.Bootstrap
             _entryPoint = new Vector3(0f, 0f, -4f);
             _exitPoint = new Vector3(0f, 0f, -5f);
             _kitchenPoint = new Vector3(-2f, 0f, 2f);
+            _kitchenPickupPoint = new Vector3(-1.5f, 0f, 2.25f);
+            _barPickupPoint = new Vector3(-2.5f, 0f, 1.25f);
+
+            var kitchenPickup = new GameObject("Kitchen_Pickup");
+            kitchenPickup.transform.position = _kitchenPickupPoint;
+            kitchenPickup.transform.SetParent(transform, false);
+
+            var barPickup = new GameObject("Bar_Pickup");
+            barPickup.transform.position = _barPickupPoint;
+            barPickup.transform.SetParent(transform, false);
 
             var bar = GameObject.CreatePrimitive(PrimitiveType.Cube);
             bar.name = "Bar";
@@ -115,26 +143,38 @@ namespace TavernSim.Bootstrap
 
             _navMeshSurface?.BuildNavMesh();
 
-            var waiterGo = GameObject.CreatePrimitive(PrimitiveType.Capsule);
-            waiterGo.name = "Waiter";
-            waiterGo.transform.position = new Vector3(-1f, 0f, 0f);
-            var waiterAgent = waiterGo.AddComponent<UnityEngine.AI.NavMeshAgent>();
-            waiterAgent.radius = 0.3f;
-            waiterAgent.height = 1.8f;
-            waiterGo.AddComponent<AgentIntentDisplay>();
-            waiterGo.AddComponent<Waiter>();
+            _waiterCount = 0;
+            _cookCount = 0;
+            _bartenderCount = 0;
+
+            _initialWaiter = CreateWaiter(GetWaiterSpawnPosition(_waiterCount));
+            _waiterCount++;
+
+            _initialBartender = CreateBartender(GetBartenderSpawnPosition(_bartenderCount));
+            _bartenderCount++;
+
+            _initialCook = CreateCook(GetCookSpawnPosition(_cookCount));
+            _cookCount++;
         }
 
         private void SetupSimulation()
         {
             _runner = gameObject.AddComponent<SimulationRunner>();
 
+            _eventBus = new GameEventBus();
+            _inventoryService ??= new DevInventoryService();
+
             _economySystem = new EconomySystem(500f, 1f);
             _orderSystem = new OrderSystem();
+            _orderSystem.SetEventBus(_eventBus);
+            _orderSystem.SetKitchenStations(2);
+            _orderSystem.SetBarStations(1);
             _cleaningSystem = new CleaningSystem(0.1f);
             _tableRegistry = new TableRegistry();
             _agentSystem = new AgentSystem(_tableRegistry, _orderSystem, _economySystem, _cleaningSystem, catalog);
-            _agentSystem.Configure(_entryPoint, _exitPoint, _kitchenPoint);
+            _agentSystem.Configure(_entryPoint, _exitPoint, _kitchenPoint, _kitchenPickupPoint, _barPickupPoint);
+            _agentSystem.SetInventory(_inventoryService);
+            _agentSystem.SetEventBus(_eventBus);
             _agentSystem.ActiveCustomerCountChanged += count => _hudController?.SetCustomers(count);
             _agentSystem.CustomerLeftAngry += HandleCustomerLeftAngry;
 
@@ -165,8 +205,10 @@ namespace TavernSim.Bootstrap
             _tableRegistry.RegisterTable(initialTable);
             _cleaningSystem.RegisterTable(initialTable);
 
-            var waiter = FindObjectOfType<Waiter>();
-            _agentSystem.RegisterWaiter(waiter);
+            if (_initialWaiter != null)
+            {
+                _agentSystem.RegisterWaiter(_initialWaiter);
+            }
 
             _debugOverlay.Configure(_agentSystem, _orderSystem);
         }
@@ -184,10 +226,24 @@ namespace TavernSim.Bootstrap
             _hudController.Initialize(_economySystem, _orderSystem);
             _hudController.BindSaveService(_saveService);
             _hudController.BindSelection(_selectionService, _gridPlacer);
+            _hudController.BindEventBus(_eventBus);
+
+            _toastController = uiGo.AddComponent<HudToastController>();
+            _toastController.Initialize(_eventBus);
+
+            _menuController = uiGo.AddComponent<MenuController>();
+            _menuController.Initialize(catalog);
+            _agentSystem.SetMenuPolicy(_menuController);
 
             _timeControls = uiGo.AddComponent<TimeControls>();
 
             EnsureEventSystem();
+
+            if (_hudController != null)
+            {
+                _hudController.HireWaiterRequested += HandleHireWaiterRequested;
+                _hudController.HireCookRequested += HandleHireCookRequested;
+            }
 
             uiGo.SetActive(true);
 
@@ -213,6 +269,105 @@ namespace TavernSim.Bootstrap
             {
                 _agentSystem.CustomerLeftAngry -= HandleCustomerLeftAngry;
             }
+
+            if (_hudController != null)
+            {
+                _hudController.HireWaiterRequested -= HandleHireWaiterRequested;
+                _hudController.HireCookRequested -= HandleHireCookRequested;
+            }
+        }
+
+        private void HandleHireWaiterRequested()
+        {
+            if (_agentSystem == null)
+            {
+                return;
+            }
+
+            var spawn = GetWaiterSpawnPosition(_waiterCount);
+            var waiter = CreateWaiter(spawn);
+            _waiterCount++;
+            _agentSystem.RegisterWaiter(waiter);
+        }
+
+        private void HandleHireCookRequested()
+        {
+            var spawn = GetCookSpawnPosition(_cookCount);
+            CreateCook(spawn);
+            _cookCount++;
+        }
+
+        private Waiter CreateWaiter(Vector3 position)
+        {
+            var index = _waiterCount + 1;
+            var waiterGo = GameObject.CreatePrimitive(PrimitiveType.Capsule);
+            waiterGo.name = index == 1 ? "Waiter" : $"Waiter_{index}";
+            waiterGo.transform.SetParent(transform, false);
+            var agent = EnsureNavMeshAgent(waiterGo);
+            if (!agent.Warp(position))
+            {
+                Debug.LogWarning($"Waiter NavMeshAgent.Warp falhou para {waiterGo.name}; verifique o NavMesh.");
+            }
+
+            waiterGo.AddComponent<AgentIntentDisplay>();
+            return waiterGo.AddComponent<Waiter>();
+        }
+
+        private Bartender CreateBartender(Vector3 position)
+        {
+            var index = _bartenderCount + 1;
+            var bartenderGo = GameObject.CreatePrimitive(PrimitiveType.Capsule);
+            bartenderGo.name = index == 1 ? "Bartender" : $"Bartender_{index}";
+            bartenderGo.transform.SetParent(transform, false);
+            var agent = EnsureNavMeshAgent(bartenderGo);
+            if (!agent.Warp(position))
+            {
+                Debug.LogWarning($"Bartender NavMeshAgent.Warp falhou para {bartenderGo.name}; verifique o NavMesh.");
+            }
+
+            return bartenderGo.AddComponent<Bartender>();
+        }
+
+        private Cook CreateCook(Vector3 position)
+        {
+            var index = _cookCount + 1;
+            var cookGo = GameObject.CreatePrimitive(PrimitiveType.Capsule);
+            cookGo.name = index == 1 ? "Cook" : $"Cook_{index}";
+            cookGo.transform.SetParent(transform, false);
+            var agent = EnsureNavMeshAgent(cookGo);
+            if (!agent.Warp(position))
+            {
+                Debug.LogWarning($"Cook NavMeshAgent.Warp falhou para {cookGo.name}; verifique o NavMesh.");
+            }
+
+            return cookGo.AddComponent<Cook>();
+        }
+
+        private static NavMeshAgent EnsureNavMeshAgent(GameObject go)
+        {
+            if (!go.TryGetComponent(out NavMeshAgent agent))
+            {
+                agent = go.AddComponent<NavMeshAgent>();
+            }
+
+            agent.radius = 0.3f;
+            agent.height = 1.8f;
+            return agent;
+        }
+
+        private static Vector3 GetWaiterSpawnPosition(int index)
+        {
+            return WaiterSpawnBase + new Vector3(-StaffSpawnSpacing * index, 0f, 0f);
+        }
+
+        private static Vector3 GetCookSpawnPosition(int index)
+        {
+            return CookSpawnBase + new Vector3(StaffSpawnSpacing * index, 0f, 0f);
+        }
+
+        private static Vector3 GetBartenderSpawnPosition(int index)
+        {
+            return BartenderSpawnBase + new Vector3(-StaffSpawnSpacing * index, 0f, 0f);
         }
 
         private static Customer CreateCustomerPrefab(Transform parent)
@@ -356,6 +511,12 @@ namespace TavernSim.Bootstrap
         private const string PanelSettingsResourcePath = "UIToolkit/DevBootstrapPanelSettings";
         private const string ThemeResourcePath = "UIToolkit/UnityThemes/UnityDefaultRuntimeTheme";
         private const string PanelTextSettingsResourcePath = "UIToolkit/DevBootstrapPanelTextSettings";
+
+        private sealed class DevInventoryService : IInventoryService
+        {
+            public bool CanCraft(RecipeSO recipe) => true;
+            public bool TryConsume(RecipeSO recipe) => true;
+        }
 
     }
 }

--- a/Assets/Building/GridPlacer.cs
+++ b/Assets/Building/GridPlacer.cs
@@ -19,13 +19,19 @@ namespace TavernSim.Building
             None = 0,
             SmallTable = 1,
             LargeTable = 2,
-            Decoration = 3
+            Decoration = 3,
+            KitchenStation = 4,
+            BarCounter = 5,
+            PickupPoint = 6
         }
 
         [SerializeField] private float gridSize = 1f;
         [SerializeField] private float smallTableCost = 125f;
         [SerializeField] private float largeTableCost = 220f;
         [SerializeField] private float decorationCost = 30f;
+        [SerializeField] private float kitchenStationCost = 420f;
+        [SerializeField] private float barCounterCost = 360f;
+        [SerializeField] private float pickupPointCost = 0f;
 
         private EconomySystem _economySystem;
         private SelectionService _selectionService;
@@ -154,6 +160,9 @@ namespace TavernSim.Building
                 PlaceableKind.SmallTable => smallTableCost,
                 PlaceableKind.LargeTable => largeTableCost,
                 PlaceableKind.Decoration => decorationCost,
+                PlaceableKind.KitchenStation => kitchenStationCost,
+                PlaceableKind.BarCounter => barCounterCost,
+                PlaceableKind.PickupPoint => pickupPointCost,
                 _ => 0f
             };
         }
@@ -183,6 +192,15 @@ namespace TavernSim.Building
                     break;
                 case PlaceableKind.Decoration:
                     CreateDecoration(position);
+                    break;
+                case PlaceableKind.KitchenStation:
+                    CreateKitchenStation(position);
+                    break;
+                case PlaceableKind.BarCounter:
+                    CreateBarCounter(position);
+                    break;
+                case PlaceableKind.PickupPoint:
+                    CreatePickupMarker(position);
                     break;
             }
         }
@@ -242,6 +260,79 @@ namespace TavernSim.Building
             foliage.transform.SetParent(planter.transform, false);
             foliage.transform.localPosition = new Vector3(0f, 0.9f, 0f);
             foliage.transform.localScale = new Vector3(1.4f, 1.4f, 1.4f);
+        }
+
+        private static void CreateKitchenStation(Vector3 position)
+        {
+            var root = new GameObject("KitchenStation");
+            root.transform.position = position;
+
+            var counter = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            counter.name = "Counter";
+            counter.transform.SetParent(root.transform, false);
+            counter.transform.localPosition = new Vector3(0f, 0.6f, 0f);
+            counter.transform.localScale = new Vector3(2.4f, 1.2f, 1.2f);
+            NavMeshSetup.MarkObstacle(counter);
+
+            var cooktop = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cooktop.name = "Cooktop";
+            cooktop.transform.SetParent(root.transform, false);
+            cooktop.transform.localPosition = new Vector3(0f, 1.25f, 0f);
+            cooktop.transform.localScale = new Vector3(2.4f, 0.2f, 1.2f);
+            NavMeshSetup.MarkObstacle(cooktop, false);
+
+            var hood = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            hood.name = "VentHood";
+            hood.transform.SetParent(root.transform, false);
+            hood.transform.localPosition = new Vector3(0f, 2f, 0f);
+            hood.transform.localScale = new Vector3(2f, 0.2f, 0.8f);
+        }
+
+        private static void CreateBarCounter(Vector3 position)
+        {
+            var root = new GameObject("BarCounter");
+            root.transform.position = position;
+
+            var body = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            body.name = "BarBody";
+            body.transform.SetParent(root.transform, false);
+            body.transform.localPosition = new Vector3(0f, 0.6f, 0f);
+            body.transform.localScale = new Vector3(2.8f, 1.2f, 0.8f);
+            NavMeshSetup.MarkObstacle(body);
+
+            var top = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            top.name = "BarTop";
+            top.transform.SetParent(root.transform, false);
+            top.transform.localPosition = new Vector3(0f, 1.25f, 0f);
+            top.transform.localScale = new Vector3(2.8f, 0.2f, 1.1f);
+            NavMeshSetup.MarkObstacle(top, false);
+
+            var shelf = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            shelf.name = "BarShelf";
+            shelf.transform.SetParent(root.transform, false);
+            shelf.transform.localPosition = new Vector3(0f, 1.8f, -0.35f);
+            shelf.transform.localScale = new Vector3(2.6f, 0.15f, 0.3f);
+        }
+
+        private static void CreatePickupMarker(Vector3 position)
+        {
+            var root = new GameObject("PickupPoint");
+            root.transform.position = position;
+
+            var baseMarker = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
+            baseMarker.name = "MarkerBase";
+            baseMarker.transform.SetParent(root.transform, false);
+            baseMarker.transform.localPosition = new Vector3(0f, 0.1f, 0f);
+            baseMarker.transform.localScale = new Vector3(0.3f, 0.1f, 0.3f);
+
+            var icon = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            icon.name = "MarkerIcon";
+            icon.transform.SetParent(root.transform, false);
+            icon.transform.localPosition = new Vector3(0f, 1f, 0f);
+            icon.transform.localScale = new Vector3(0.4f, 0.4f, 0.4f);
+
+            Object.Destroy(baseMarker.GetComponent<Collider>());
+            Object.Destroy(icon.GetComponent<Collider>());
         }
     }
 

--- a/Assets/Core/GameEvents.cs
+++ b/Assets/Core/GameEvents.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+
+namespace TavernSim.Core
+{
+    public enum GameEventSeverity
+    {
+        Info = 0,
+        Warning = 1,
+        Error = 2
+    }
+
+    public readonly struct GameEvent
+    {
+        public string Code { get; }
+        public string Message { get; }
+        public GameEventSeverity Severity { get; }
+        public IReadOnlyDictionary<string, object> Data { get; }
+        public DateTime Time { get; }
+
+        public GameEvent(string code, string message, GameEventSeverity severity, IReadOnlyDictionary<string, object> data = null)
+        {
+            Code = code ?? string.Empty;
+            Message = message ?? string.Empty;
+            Severity = severity;
+            Data = data ?? EmptyData;
+            Time = DateTime.UtcNow;
+        }
+
+        private static readonly IReadOnlyDictionary<string, object> EmptyData = new Dictionary<string, object>();
+    }
+
+    public interface IEventSink
+    {
+        void Receive(GameEvent gameEvent);
+    }
+
+    public interface IEventBus
+    {
+        void Publish(GameEvent gameEvent);
+        void Subscribe(IEventSink sink);
+        void Unsubscribe(IEventSink sink);
+    }
+
+    public sealed class GameEventBus : IEventBus
+    {
+        private readonly List<IEventSink> _sinks = new List<IEventSink>(8);
+
+        public void Publish(GameEvent gameEvent)
+        {
+            for (int i = 0; i < _sinks.Count; i++)
+            {
+                _sinks[i]?.Receive(gameEvent);
+            }
+        }
+
+        public void Subscribe(IEventSink sink)
+        {
+            if (sink == null || _sinks.Contains(sink))
+            {
+                return;
+            }
+
+            _sinks.Add(sink);
+        }
+
+        public void Unsubscribe(IEventSink sink)
+        {
+            if (sink == null)
+            {
+                return;
+            }
+
+            _sinks.Remove(sink);
+        }
+    }
+}
+
+namespace TavernSim.Core.Events
+{
+    using GameEvent = TavernSim.Core.GameEvent;
+    using GameEventBus = TavernSim.Core.GameEventBus;
+    using GameEventSeverity = TavernSim.Core.GameEventSeverity;
+    using IEventBus = TavernSim.Core.IEventBus;
+    using IEventSink = TavernSim.Core.IEventSink;
+}

--- a/Assets/Core/GameEvents.cs.meta
+++ b/Assets/Core/GameEvents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bdbceca4-8613-457a-8f55-a51cc2a9e8eb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Simulation/Systems/AgentSystem.cs
+++ b/Assets/Simulation/Systems/AgentSystem.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.AI;
 using TavernSim.Agents;
+using TavernSim.Core;
 using TavernSim.Core.Simulation;
 using TavernSim.Domain;
 using TavernSim.Simulation.Models;
@@ -34,8 +36,13 @@ namespace TavernSim.Simulation.Systems
 
         private Vector3 _entryPoint;
         private Vector3 _exitPoint;
-        private Vector3 _kitchenPoint;
+        private Vector3 _kitchenPickupPoint;
+        private Vector3 _barPickupPoint;
         private RecipeSO _defaultRecipe;
+        private IMenuPolicy _menuPolicy;
+        private IInventoryService _inventory;
+        private OrderRequestValidator _orderValidator;
+        private IEventBus _eventBus;
 
         public event Action<int> ActiveCustomerCountChanged;
         public int ActiveCustomerCount => _customers.Count;
@@ -49,13 +56,37 @@ namespace TavernSim.Simulation.Systems
             _economySystem = economySystem;
             _cleaningSystem = cleaningSystem;
             _catalog = catalog;
+            _orderValidator = new OrderRequestValidator(null, null);
         }
 
         public void Configure(Vector3 entryPoint, Vector3 exitPoint, Vector3 kitchenPoint)
         {
+            Configure(entryPoint, exitPoint, kitchenPoint, kitchenPoint, kitchenPoint);
+        }
+
+        public void Configure(Vector3 entryPoint, Vector3 exitPoint, Vector3 kitchenPoint, Vector3 kitchenPickupPoint, Vector3 barPickupPoint)
+        {
             _entryPoint = entryPoint;
             _exitPoint = exitPoint;
-            _kitchenPoint = kitchenPoint;
+            _kitchenPickupPoint = kitchenPickupPoint;
+            _barPickupPoint = barPickupPoint;
+        }
+
+        public void SetMenuPolicy(IMenuPolicy menuPolicy)
+        {
+            _menuPolicy = menuPolicy;
+            _orderValidator = new OrderRequestValidator(_menuPolicy, _inventory);
+        }
+
+        public void SetInventory(IInventoryService inventory)
+        {
+            _inventory = inventory;
+            _orderValidator = new OrderRequestValidator(_menuPolicy, _inventory);
+        }
+
+        public void SetEventBus(IEventBus eventBus)
+        {
+            _eventBus = eventBus;
         }
 
         public void Initialize(Sim simulation)
@@ -118,8 +149,23 @@ namespace TavernSim.Simulation.Systems
                 StateTimer = 0f
             };
             customer.gameObject.SetActive(true);
-            customer.transform.position = _entryPoint;
+            var navAgent = customer.Agent;
+            if (navAgent != null && navAgent.isOnNavMesh)
+            {
+                navAgent.Warp(_entryPoint);
+            }
+            else
+            {
+                customer.transform.position = _entryPoint;
+            }
             customer.SetDestination(_entryPoint);
+            data.Favorite = _defaultRecipe;
+            data.Gold = UnityEngine.Random.Range(8, 24);
+            data.Patience = UnityEngine.Random.Range(10f, 25f);
+            data.Name = $"Cliente {UnityEngine.Random.Range(1000, 9999)}";
+            data.OrderBlocked = false;
+            data.BlockReason = string.Empty;
+            data.WaiterAssigned = false;
             _customers.Add(data);
             ActiveCustomerCountChanged?.Invoke(_customers.Count);
             UpdateCustomerIntent(data);
@@ -270,6 +316,8 @@ namespace TavernSim.Simulation.Systems
                         data.State = CustomerState.Leave;
                         data.StateTimer = 0f;
                         data.SearchTimer = 0f;
+                        data.BlockReason = "Sem mesas disponíveis";
+                        PublishCustomerAngry(data, data.BlockReason, -1);
                         CustomerLeftAngry?.Invoke(data.Agent);
                         return;
                     }
@@ -292,6 +340,9 @@ namespace TavernSim.Simulation.Systems
                 data.State = CustomerState.Order;
                 data.StateTimer = 0f;
                 data.WaitTimer = 0f;
+                data.WaiterAssigned = false;
+                data.OrderBlocked = false;
+                data.BlockReason = string.Empty;
                 if (!_customersNeedingOrder.Contains(data.Agent))
                 {
                     _customersNeedingOrder.Add(data.Agent);
@@ -303,12 +354,36 @@ namespace TavernSim.Simulation.Systems
         {
             data.WaitTimer += deltaTime;
             data.TotalWaitTime += deltaTime;
+            if (data.PendingRecipe == null)
+            {
+                data.PendingRecipe = data.Favorite ?? _defaultRecipe;
+            }
+
+            if (data.OrderBlocked)
+            {
+                if (CanAttemptOrder(data.PendingRecipe))
+                {
+                    data.OrderBlocked = false;
+                    data.BlockReason = string.Empty;
+                    if (!data.WaiterAssigned && !_customersNeedingOrder.Contains(data.Agent))
+                    {
+                        _customersNeedingOrder.Add(data.Agent);
+                    }
+                }
+            }
+            else if (!data.WaiterAssigned && !_customersNeedingOrder.Contains(data.Agent))
+            {
+                _customersNeedingOrder.Add(data.Agent);
+            }
+
+            CheckPatience(ref data);
         }
 
         private void HandleWaitDrink(ref CustomerData data, float deltaTime)
         {
             data.WaitTimer += deltaTime;
             data.TotalWaitTime += deltaTime;
+            CheckPatience(ref data);
         }
 
         private void HandleEat(ref CustomerData data, float deltaTime)
@@ -359,6 +434,9 @@ namespace TavernSim.Simulation.Systems
 
             data.CurrentRecipe = null;
             data.PendingRecipe = null;
+            data.OrderBlocked = false;
+            data.WaiterAssigned = false;
+            data.BlockReason = string.Empty;
         }
 
         private void HandlePay(ref CustomerData data)
@@ -393,6 +471,9 @@ namespace TavernSim.Simulation.Systems
             data.TotalWaitTime = 0f;
             data.PendingRecipe = null;
             data.CurrentRecipe = null;
+            data.OrderBlocked = false;
+            data.WaiterAssigned = false;
+            data.BlockReason = string.Empty;
             if (data.Table != null)
             {
                 if (!_tablesNeedingClean.Contains(data.Table.Id))
@@ -418,20 +499,8 @@ namespace TavernSim.Simulation.Systems
 
         private void HandleWaiterIdle(ref WaiterData data)
         {
-            if (_customersNeedingOrder.Count > 0)
+            if (TryAssignNextCustomer(ref data))
             {
-                var customer = _customersNeedingOrder[0];
-                _customersNeedingOrder.RemoveAt(0);
-                data.TargetCustomer = customer;
-                if (customer != null)
-                {
-                    var customerData = FindCustomerData(customer);
-                    if (customerData != null && customerData.Seat != null)
-                    {
-                        data.Agent.SetDestination(customerData.Seat.Anchor.position);
-                        data.State = WaiterState.TakeOrder;
-                    }
-                }
                 return;
             }
 
@@ -448,7 +517,7 @@ namespace TavernSim.Simulation.Systems
                 return;
             }
 
-            data.Agent.SetDestination(_kitchenPoint);
+            data.Agent.SetDestination(GetPickupPoint(PrepArea.Kitchen));
         }
 
         private void HandleWaiterTakeOrder(ref WaiterData data)
@@ -474,17 +543,45 @@ namespace TavernSim.Simulation.Systems
             var recipe = customerData.PendingRecipe ?? _defaultRecipe;
             if (recipe != null && customerData.Table != null)
             {
-                _orderSystem.EnqueueOrder(customerData.Table.Id, recipe);
+                customerData.PendingRecipe = recipe;
+                var validation = _orderValidator != null ? _orderValidator.Validate(recipe) : OrderValidationResult.Allowed;
+                if (!validation.IsAllowed)
+                {
+                    customerData.OrderBlocked = true;
+                    customerData.WaiterAssigned = false;
+                    switch (validation.Reason)
+                    {
+                        case OrderBlockReason.MenuPolicy:
+                            customerData.BlockReason = "Bloqueado pelo cardápio";
+                            PublishOrderBlockedByMenu(customerData, recipe);
+                            break;
+                        case OrderBlockReason.InventoryUnavailable:
+                            customerData.BlockReason = "Sem ingredientes";
+                            PublishNoIngredients(customerData, recipe);
+                            break;
+                    }
+
+                    data.TargetCustomer = null;
+                    data.State = WaiterState.Idle;
+                    data.Agent.SetDestination(GetPickupPoint(PrepArea.Kitchen));
+                    return;
+                }
+
                 customerData.State = CustomerState.WaitDrink;
                 customerData.WaitTimer = 0f;
                 customerData.PendingRecipe = recipe;
-                data.Agent.SetDestination(_kitchenPoint);
+                customerData.OrderBlocked = false;
+                customerData.WaiterAssigned = false;
+                customerData.BlockReason = string.Empty;
+
+                var area = _orderSystem.EnqueueOrder(customerData.Table.Id, recipe);
+                data.TargetArea = area;
+                data.Agent.SetDestination(GetPickupPoint(area));
                 data.State = WaiterState.WaitPrep;
+                return;
             }
-            else
-            {
-                data.State = WaiterState.Idle;
-            }
+
+            data.State = WaiterState.Idle;
         }
 
         private void HandleWaiterWaitPrep(ref WaiterData data)
@@ -507,9 +604,10 @@ namespace TavernSim.Simulation.Systems
                 return;
             }
 
-            if (_orderSystem.TryConsumeReadyOrder(customerData.Table.Id, out var recipe))
+            if (_orderSystem.TryConsumeReadyOrder(customerData.Table.Id, out var recipe, out var area))
             {
                 data.CarryingRecipe = recipe;
+                data.CarryingArea = area;
                 data.Agent.SetDestination(customerData.Seat.Anchor.position);
                 data.State = WaiterState.Deliver;
             }
@@ -536,10 +634,16 @@ namespace TavernSim.Simulation.Systems
                 customerData.CurrentRecipe = data.CarryingRecipe ?? customerData.PendingRecipe;
                 customerData.PendingRecipe = null;
                 customerData.WaitTimer = 0f;
+                customerData.OrderBlocked = false;
+                customerData.WaiterAssigned = false;
+                customerData.BlockReason = string.Empty;
+                PublishOrderDelivered(customerData, data.CarryingRecipe ?? customerData.CurrentRecipe, data.CarryingArea);
             }
 
             data.CarryingRecipe = null;
+            data.CarryingArea = PrepArea.Kitchen;
             data.TargetCustomer = null;
+            data.TargetArea = PrepArea.Kitchen;
             data.State = WaiterState.Idle;
         }
 
@@ -559,6 +663,54 @@ namespace TavernSim.Simulation.Systems
             data.State = WaiterState.Idle;
         }
 
+        private bool TryAssignNextCustomer(ref WaiterData data)
+        {
+            for (int i = 0; i < _customersNeedingOrder.Count; i++)
+            {
+                var customer = _customersNeedingOrder[i];
+                if (customer == null)
+                {
+                    _customersNeedingOrder.RemoveAt(i);
+                    i--;
+                    continue;
+                }
+
+                var customerData = FindCustomerData(customer);
+                if (customerData == null || customerData.Seat == null)
+                {
+                    _customersNeedingOrder.RemoveAt(i);
+                    i--;
+                    continue;
+                }
+
+                if (customerData.WaiterAssigned)
+                {
+                    _customersNeedingOrder.RemoveAt(i);
+                    i--;
+                    continue;
+                }
+
+                _customersNeedingOrder.RemoveAt(i);
+                data.TargetCustomer = customer;
+                customerData.WaiterAssigned = true;
+                data.Agent.SetDestination(customerData.Seat.Anchor.position);
+                data.State = WaiterState.TakeOrder;
+                return true;
+            }
+
+            return false;
+        }
+
+        private Vector3 GetPickupPoint(PrepArea area)
+        {
+            if (area == PrepArea.Bar)
+            {
+                return _barPickupPoint != Vector3.zero ? _barPickupPoint : _kitchenPickupPoint;
+            }
+
+            return _kitchenPickupPoint != Vector3.zero ? _kitchenPickupPoint : _entryPoint;
+        }
+
         private CustomerData FindCustomerData(Customer customer)
         {
             for (int i = 0; i < _customers.Count; i++)
@@ -570,6 +722,139 @@ namespace TavernSim.Simulation.Systems
             }
 
             return null;
+        }
+
+        private bool CanAttemptOrder(RecipeSO recipe)
+        {
+            if (recipe == null)
+            {
+                return false;
+            }
+
+            if (_menuPolicy != null && !_menuPolicy.IsAllowed(recipe))
+            {
+                return false;
+            }
+
+            if (_inventory != null && !_inventory.CanCraft(recipe))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private void CheckPatience(ref CustomerData data)
+        {
+            if (data.Patience <= 0f)
+            {
+                return;
+            }
+
+            if (data.WaitTimer < data.Patience)
+            {
+                return;
+            }
+
+            data.LeftAngry = true;
+            data.Agent.StandUp();
+            data.Agent.SetDestination(_exitPoint);
+            data.State = CustomerState.Leave;
+            data.StateTimer = 0f;
+            data.WaitTimer = 0f;
+            data.OrderBlocked = false;
+            data.WaiterAssigned = false;
+            var reason = !string.IsNullOrEmpty(data.BlockReason) ? data.BlockReason : "Demorou demais";
+            var tableId = data.Table != null ? data.Table.Id : -1;
+            if (data.Table != null && !_tablesNeedingClean.Contains(data.Table.Id))
+            {
+                _tablesNeedingClean.Add(data.Table.Id);
+            }
+
+            _customersNeedingOrder.Remove(data.Agent);
+            data.PendingRecipe = null;
+            data.CurrentRecipe = null;
+            PublishCustomerAngry(data, reason, tableId);
+            CustomerLeftAngry?.Invoke(data.Agent);
+            data.BlockReason = string.Empty;
+        }
+
+        private void PublishOrderBlockedByMenu(CustomerData data, RecipeSO recipe)
+        {
+            if (_eventBus == null)
+            {
+                return;
+            }
+
+            var tableId = data.Table != null ? data.Table.Id : -1;
+            var recipeName = recipe != null ? recipe.DisplayName : "Desconhecido";
+            var eventData = new Dictionary<string, object>
+            {
+                ["tableId"] = tableId,
+                ["recipeId"] = recipe != null ? recipe.Id : string.Empty
+            };
+
+            var message = $"Pedido da mesa {tableId} bloqueado pelo cardápio: {recipeName}";
+            _eventBus.Publish(new GameEvent("OrderBlockedByMenu", message, GameEventSeverity.Warning, eventData));
+        }
+
+        private void PublishNoIngredients(CustomerData data, RecipeSO recipe)
+        {
+            if (_eventBus == null)
+            {
+                return;
+            }
+
+            var tableId = data.Table != null ? data.Table.Id : -1;
+            var recipeName = recipe != null ? recipe.DisplayName : "Desconhecido";
+            var eventData = new Dictionary<string, object>
+            {
+                ["tableId"] = tableId,
+                ["recipeId"] = recipe != null ? recipe.Id : string.Empty
+            };
+
+            var message = $"Sem ingredientes para {recipeName} na mesa {tableId}";
+            _eventBus.Publish(new GameEvent("NoIngredients", message, GameEventSeverity.Warning, eventData));
+        }
+
+        private void PublishCustomerAngry(CustomerData data, string reason, int tableId)
+        {
+            if (_eventBus == null)
+            {
+                return;
+            }
+
+            var eventData = new Dictionary<string, object>
+            {
+                ["tableId"] = tableId,
+                ["customerName"] = data.Name ?? (data.Agent != null ? data.Agent.name : string.Empty),
+                ["reason"] = reason
+            };
+
+            var displayName = data.Name ?? (data.Agent != null ? data.Agent.name : "Cliente");
+            var message = $"{displayName} deixou a mesa {tableId} irritado: {reason}";
+            _eventBus.Publish(new GameEvent("CustomerAngry", message, GameEventSeverity.Warning, eventData));
+        }
+
+        private void PublishOrderDelivered(CustomerData data, RecipeSO recipe, PrepArea area)
+        {
+            if (_eventBus == null)
+            {
+                return;
+            }
+
+            var tableId = data.Table != null ? data.Table.Id : -1;
+            var recipeName = recipe != null ? recipe.DisplayName : "Pedido";
+            var eventData = new Dictionary<string, object>
+            {
+                ["tableId"] = tableId,
+                ["recipeId"] = recipe != null ? recipe.Id : string.Empty,
+                ["area"] = area.ToString()
+            };
+
+            var areaLabel = area.GetDisplayName();
+            var message = $"Pedido entregue ({areaLabel}) - Mesa {tableId}: {recipeName}";
+            _eventBus.Publish(new GameEvent("OrderDelivered", message, GameEventSeverity.Info, eventData));
         }
 
         private static float CalculateTip(float waitTime)
@@ -680,6 +965,13 @@ namespace TavernSim.Simulation.Systems
             public float BillCost;
             public RecipeSO PendingRecipe;
             public RecipeSO CurrentRecipe;
+            public int Gold;
+            public float Patience;
+            public string Name;
+            public RecipeSO Favorite;
+            public bool WaiterAssigned;
+            public bool OrderBlocked;
+            public string BlockReason;
 
             public CustomerData(Customer agent)
             {
@@ -688,6 +980,13 @@ namespace TavernSim.Simulation.Systems
                 CompletedCourses = 0;
                 BillRevenue = 0f;
                 BillCost = 0f;
+                Gold = UnityEngine.Random.Range(8, 24);
+                Patience = UnityEngine.Random.Range(10f, 25f);
+                Name = $"Cliente {UnityEngine.Random.Range(1000, 9999)}";
+                Favorite = null;
+                WaiterAssigned = false;
+                OrderBlocked = false;
+                BlockReason = string.Empty;
             }
 
             public void Reset()
@@ -707,6 +1006,13 @@ namespace TavernSim.Simulation.Systems
                 PendingRecipe = null;
                 CurrentRecipe = null;
                 DesiredCourses = UnityEngine.Random.Range(1, 3);
+                Gold = UnityEngine.Random.Range(8, 24);
+                Patience = UnityEngine.Random.Range(10f, 25f);
+                Name = $"Cliente {UnityEngine.Random.Range(1000, 9999)}";
+                Favorite = null;
+                WaiterAssigned = false;
+                OrderBlocked = false;
+                BlockReason = string.Empty;
             }
         }
 
@@ -718,11 +1024,15 @@ namespace TavernSim.Simulation.Systems
             public Customer TargetCustomer;
             public int TargetTableId = -1;
             public RecipeSO CarryingRecipe;
+            public PrepArea TargetArea;
+            public PrepArea CarryingArea;
 
             public WaiterData(Waiter agent)
             {
                 Agent = agent;
                 State = WaiterState.Idle;
+                TargetArea = PrepArea.Kitchen;
+                CarryingArea = PrepArea.Kitchen;
             }
         }
     }

--- a/Assets/Simulation/Systems/OrderRequestValidator.cs
+++ b/Assets/Simulation/Systems/OrderRequestValidator.cs
@@ -1,0 +1,80 @@
+using TavernSim.Domain;
+
+namespace TavernSim.Simulation.Systems
+{
+    public enum OrderBlockReason
+    {
+        None = 0,
+        MenuPolicy = 1,
+        InventoryUnavailable = 2
+    }
+
+    public readonly struct OrderValidationResult
+    {
+        public bool IsAllowed { get; }
+        public OrderBlockReason Reason { get; }
+
+        public OrderValidationResult(bool isAllowed, OrderBlockReason reason)
+        {
+            IsAllowed = isAllowed;
+            Reason = reason;
+        }
+
+        public static OrderValidationResult Allowed => new OrderValidationResult(true, OrderBlockReason.None);
+        public static OrderValidationResult MenuBlocked => new OrderValidationResult(false, OrderBlockReason.MenuPolicy);
+        public static OrderValidationResult InventoryBlocked => new OrderValidationResult(false, OrderBlockReason.InventoryUnavailable);
+    }
+
+    public interface IMenuPolicy
+    {
+        bool IsAllowed(RecipeSO recipe);
+    }
+
+    public interface IInventoryService
+    {
+        bool CanCraft(RecipeSO recipe);
+        bool TryConsume(RecipeSO recipe);
+    }
+
+    public sealed class OrderRequestValidator
+    {
+        private readonly IMenuPolicy _menuPolicy;
+        private readonly IInventoryService _inventory;
+
+        public OrderRequestValidator(IMenuPolicy menuPolicy, IInventoryService inventory)
+        {
+            _menuPolicy = menuPolicy;
+            _inventory = inventory;
+        }
+
+        public OrderValidationResult Validate(RecipeSO recipe)
+        {
+            if (recipe == null)
+            {
+                return OrderValidationResult.Allowed;
+            }
+
+            if (_menuPolicy != null && !_menuPolicy.IsAllowed(recipe))
+            {
+                return OrderValidationResult.MenuBlocked;
+            }
+
+            if (_inventory == null)
+            {
+                return OrderValidationResult.Allowed;
+            }
+
+            if (!_inventory.CanCraft(recipe))
+            {
+                return OrderValidationResult.InventoryBlocked;
+            }
+
+            if (!_inventory.TryConsume(recipe))
+            {
+                return OrderValidationResult.InventoryBlocked;
+            }
+
+            return OrderValidationResult.Allowed;
+        }
+    }
+}

--- a/Assets/Simulation/Systems/OrderRequestValidator.cs.meta
+++ b/Assets/Simulation/Systems/OrderRequestValidator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 51408010-4b3a-4359-a752-d778cecd797c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Simulation/Systems/OrderSystem.cs
+++ b/Assets/Simulation/Systems/OrderSystem.cs
@@ -1,49 +1,116 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
+using TavernSim.Core;
 using TavernSim.Core.Simulation;
+using TavernSim.Domain;
+
 using Sim = TavernSim.Core.Simulation.Simulation;
 
 namespace TavernSim.Simulation.Systems
 {
+    public enum PrepArea
+    {
+        Kitchen = 0,
+        Bar = 1
+    }
+
+    public enum OrderState
+    {
+        Queued = 0,
+        InPreparation = 1
+    }
+
     public sealed class OrderSystem : ISimSystem
     {
-        private readonly Queue<Order> _pending = new(32);
-        private readonly List<Order> _inPrep = new(32);
-        private int _maxStations = 1;
+        private const string DefaultKitchenKeyword = "cozinha";
+        private static readonly string[] BarKeywords =
+        {
+            "bar",
+            "drink",
+            "bebida",
+            "cerveja",
+            "beer",
+            "wine",
+            "ale",
+            "coquetel",
+            "cocktail"
+        };
 
-        public event System.Action<IReadOnlyList<Order>> OrdersChanged;
+        private readonly Queue<Order> _kitchenQueue = new Queue<Order>(32);
+        private readonly Queue<Order> _barQueue = new Queue<Order>(16);
+        private readonly List<Order> _kitchenInPrep = new List<Order>(32);
+        private readonly List<Order> _barInPrep = new List<Order>(16);
+        private readonly List<Order> _ordersView = new List<Order>(48);
 
-        public void SetKitchenStations(int count) => _maxStations = Mathf.Max(1, count);
+        private int _kitchenStations = 1;
+        private int _barStations = 1;
+        private bool _viewDirty;
 
-        public void EnqueueOrder(int tableId, TavernSim.Domain.RecipeSO recipe)
+        private IEventBus _eventBus;
+
+        public event Action<IReadOnlyList<Order>> OrdersChanged;
+
+        public void SetEventBus(IEventBus eventBus)
+        {
+            _eventBus = eventBus;
+        }
+
+        public void SetKitchenStations(int count)
+        {
+            _kitchenStations = Mathf.Max(1, count);
+        }
+
+        public void SetBarStations(int count)
+        {
+            _barStations = Mathf.Max(1, count);
+        }
+
+        public PrepArea EnqueueOrder(int tableId, RecipeSO recipe)
         {
             if (recipe == null)
             {
-                return;
+                return PrepArea.Kitchen;
             }
 
-            _pending.Enqueue(new Order(tableId, recipe, recipe.PrepTime));
-            OrdersChanged?.Invoke(GetOrders());
+            var area = ResolveArea(recipe);
+            var order = new Order(tableId, recipe, recipe.PrepTime, area);
+            GetQueue(area).Enqueue(order);
+            _viewDirty = true;
+            RaiseOrdersChanged();
+            return area;
         }
 
-        public bool TryConsumeReadyOrder(int tableId, out TavernSim.Domain.RecipeSO recipe)
+        public bool TryConsumeReadyOrder(int tableId, out RecipeSO recipe, out PrepArea area)
         {
-            for (int i = 0; i < _inPrep.Count; i++)
+            if (TryConsumeFromList(_kitchenInPrep, tableId, out recipe, out area))
             {
-                if (_inPrep[i].TableId == tableId && _inPrep[i].Remaining <= 0f)
-                {
-                    recipe = _inPrep[i].Recipe;
-                    _inPrep.RemoveAt(i);
-                    OrdersChanged?.Invoke(GetOrders());
-                    return true;
-                }
+                _viewDirty = true;
+                RaiseOrdersChanged();
+                return true;
+            }
+
+            if (TryConsumeFromList(_barInPrep, tableId, out recipe, out area))
+            {
+                _viewDirty = true;
+                RaiseOrdersChanged();
+                return true;
             }
 
             recipe = null;
+            area = PrepArea.Kitchen;
             return false;
         }
 
-        public IReadOnlyList<Order> GetOrders() => _inPrep;
+        public IReadOnlyList<Order> GetOrders()
+        {
+            if (_viewDirty)
+            {
+                RebuildOrdersView();
+            }
+
+            return _ordersView;
+        }
 
         public void Initialize(Sim simulation)
         {
@@ -51,22 +118,17 @@ namespace TavernSim.Simulation.Systems
 
         public void Tick(float dt)
         {
-            while (_inPrep.Count < _maxStations && _pending.Count > 0)
-            {
-                _inPrep.Add(_pending.Dequeue());
-            }
-
             bool changed = false;
-            for (int i = 0; i < _inPrep.Count; i++)
-            {
-                float previous = _inPrep[i].Remaining;
-                _inPrep[i].Remaining = Mathf.Max(0f, previous - dt);
-                changed |= _inPrep[i].Remaining != previous;
-            }
+
+            changed |= FillStations(_kitchenQueue, _kitchenInPrep, _kitchenStations);
+            changed |= FillStations(_barQueue, _barInPrep, _barStations);
+
+            changed |= ProgressOrders(_kitchenInPrep, dt);
+            changed |= ProgressOrders(_barInPrep, dt);
 
             if (changed)
             {
-                OrdersChanged?.Invoke(GetOrders());
+                RaiseOrdersChanged();
             }
         }
 
@@ -76,22 +138,196 @@ namespace TavernSim.Simulation.Systems
 
         public void Dispose()
         {
-            _pending.Clear();
-            _inPrep.Clear();
+            _kitchenQueue.Clear();
+            _barQueue.Clear();
+            _kitchenInPrep.Clear();
+            _barInPrep.Clear();
+            _ordersView.Clear();
+            _viewDirty = true;
+            OrdersChanged = null;
+        }
+
+        private bool TryConsumeFromList(List<Order> list, int tableId, out RecipeSO recipe, out PrepArea area)
+        {
+            for (int i = 0; i < list.Count; i++)
+            {
+                var order = list[i];
+                if (order.TableId != tableId || !order.IsReady)
+                {
+                    continue;
+                }
+
+                recipe = order.Recipe;
+                area = order.Area;
+                list.RemoveAt(i);
+                return true;
+            }
+
+            recipe = null;
+            area = PrepArea.Kitchen;
+            return false;
+        }
+
+        private bool FillStations(Queue<Order> queue, List<Order> active, int stationLimit)
+        {
+            bool changed = false;
+            while (active.Count < stationLimit && queue.Count > 0)
+            {
+                var order = queue.Dequeue();
+                order.MarkInPreparation();
+                active.Add(order);
+                changed = true;
+            }
+
+            if (changed)
+            {
+                _viewDirty = true;
+            }
+
+            return changed;
+        }
+
+        private bool ProgressOrders(List<Order> orders, float deltaTime)
+        {
+            bool changed = false;
+            for (int i = 0; i < orders.Count; i++)
+            {
+                var order = orders[i];
+                if (order.IsReady)
+                {
+                    continue;
+                }
+
+                float previous = order.Remaining;
+                order.Remaining = Mathf.Max(0f, previous - deltaTime);
+                if (!Mathf.Approximately(previous, order.Remaining))
+                {
+                    changed = true;
+                }
+
+                if (!order.IsReady && order.Remaining <= 0f)
+                {
+                    order.MarkReady();
+                    PublishOrderReady(order);
+                    changed = true;
+                }
+            }
+
+            return changed;
+        }
+
+        private void PublishOrderReady(Order order)
+        {
+            if (_eventBus == null)
+            {
+                return;
+            }
+
+            var data = new Dictionary<string, object>
+            {
+                ["tableId"] = order.TableId,
+                ["recipeId"] = order.Recipe != null ? order.Recipe.Id : string.Empty,
+                ["area"] = order.Area.ToString()
+            };
+            var areaLabel = order.Area.GetDisplayName();
+            var recipeName = order.Recipe != null ? order.Recipe.DisplayName : "Desconhecido";
+            var message = $"Pedido pronto ({areaLabel}) - Mesa {order.TableId}: {recipeName}";
+            _eventBus.Publish(new GameEvent("OrderReady", message, GameEventSeverity.Info, data));
+        }
+
+        private void RaiseOrdersChanged()
+        {
+            if (_viewDirty)
+            {
+                RebuildOrdersView();
+            }
+
+            OrdersChanged?.Invoke(_ordersView);
+        }
+
+        private void RebuildOrdersView()
+        {
+            _ordersView.Clear();
+            _ordersView.AddRange(_kitchenInPrep);
+            _ordersView.AddRange(_barInPrep);
+            foreach (var order in _kitchenQueue)
+            {
+                _ordersView.Add(order);
+            }
+
+            foreach (var order in _barQueue)
+            {
+                _ordersView.Add(order);
+            }
+
+            _viewDirty = false;
+        }
+
+        private Queue<Order> GetQueue(PrepArea area)
+        {
+            return area == PrepArea.Bar ? _barQueue : _kitchenQueue;
+        }
+
+        private static PrepArea ResolveArea(RecipeSO recipe)
+        {
+            if (recipe == null)
+            {
+                return PrepArea.Kitchen;
+            }
+
+            var source = (recipe.DisplayName + " " + recipe.Id).ToLowerInvariant();
+            for (int i = 0; i < BarKeywords.Length; i++)
+            {
+                if (source.Contains(BarKeywords[i]))
+                {
+                    return PrepArea.Bar;
+                }
+            }
+
+            if (source.Contains(DefaultKitchenKeyword))
+            {
+                return PrepArea.Kitchen;
+            }
+
+            return PrepArea.Kitchen;
         }
     }
 
     public sealed class Order
     {
         public int TableId { get; }
-        public TavernSim.Domain.RecipeSO Recipe { get; }
+        public RecipeSO Recipe { get; }
+        public PrepArea Area { get; }
+        public OrderState State { get; private set; }
         public float Remaining { get; set; }
+        public bool IsReady { get; private set; }
 
-        public Order(int tableId, TavernSim.Domain.RecipeSO recipe, float prepTime)
+        public Order(int tableId, RecipeSO recipe, float prepTime, PrepArea area)
         {
             TableId = tableId;
             Recipe = recipe;
+            Area = area;
             Remaining = Mathf.Max(0f, prepTime);
+            State = OrderState.Queued;
+            IsReady = false;
+        }
+
+        public void MarkInPreparation()
+        {
+            State = OrderState.InPreparation;
+        }
+
+        public void MarkReady()
+        {
+            IsReady = true;
+        }
+    }
+
+    public static class PrepAreaExtensions
+    {
+        public static string GetDisplayName(this PrepArea area)
+        {
+            return area == PrepArea.Bar ? "Bar" : "Cozinha";
         }
     }
 }

--- a/Assets/Tests/EditMode/EconomySystemTests.cs
+++ b/Assets/Tests/EditMode/EconomySystemTests.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR
+#if UNITY_INCLUDE_TESTS
 using NUnit.Framework;
 using TavernSim.Simulation.Systems;
 

--- a/Assets/Tests/EditMode/OrderRequestValidatorTests.cs
+++ b/Assets/Tests/EditMode/OrderRequestValidatorTests.cs
@@ -1,0 +1,73 @@
+#if UNITY_INCLUDE_TESTS
+using System.Reflection;
+using NUnit.Framework;
+using TavernSim.Domain;
+using TavernSim.Simulation.Systems;
+using UnityEngine;
+
+public class OrderRequestValidatorTests
+{
+    [Test]
+    public void MenuPolicyBlocksOrder()
+    {
+        var recipe = CreateRecipe("drink", "Bebida", 1f);
+        var policy = new StubMenuPolicy(false);
+        var inventory = new StubInventory(true, true);
+        var validator = new OrderRequestValidator(policy, inventory);
+
+        var result = validator.Validate(recipe);
+        Assert.IsFalse(result.IsAllowed);
+        Assert.AreEqual(OrderBlockReason.MenuPolicy, result.Reason);
+    }
+
+    [Test]
+    public void InventoryAllowsOrder()
+    {
+        var recipe = CreateRecipe("soup", "Sopa", 1f);
+        var policy = new StubMenuPolicy(true);
+        var inventory = new StubInventory(true, true);
+        var validator = new OrderRequestValidator(policy, inventory);
+
+        var result = validator.Validate(recipe);
+        Assert.IsTrue(result.IsAllowed);
+        Assert.AreEqual(OrderBlockReason.None, result.Reason);
+    }
+
+    private static RecipeSO CreateRecipe(string id, string name, float prepTime)
+    {
+        var recipe = ScriptableObject.CreateInstance<RecipeSO>();
+        typeof(RecipeSO).GetField("id", BindingFlags.Instance | BindingFlags.NonPublic)?.SetValue(recipe, id);
+        typeof(RecipeSO).GetField("displayName", BindingFlags.Instance | BindingFlags.NonPublic)?.SetValue(recipe, name);
+        typeof(RecipeSO).GetField("prepTime", BindingFlags.Instance | BindingFlags.NonPublic)?.SetValue(recipe, prepTime);
+        return recipe;
+    }
+
+    private sealed class StubMenuPolicy : IMenuPolicy
+    {
+        private readonly bool _allowed;
+
+        public StubMenuPolicy(bool allowed)
+        {
+            _allowed = allowed;
+        }
+
+        public bool IsAllowed(RecipeSO recipe) => _allowed;
+    }
+
+    private sealed class StubInventory : IInventoryService
+    {
+        private readonly bool _canCraft;
+        private readonly bool _consume;
+
+        public StubInventory(bool canCraft, bool consume)
+        {
+            _canCraft = canCraft;
+            _consume = consume;
+        }
+
+        public bool CanCraft(RecipeSO recipe) => _canCraft;
+
+        public bool TryConsume(RecipeSO recipe) => _consume;
+    }
+}
+#endif

--- a/Assets/Tests/EditMode/OrderRequestValidatorTests.cs.meta
+++ b/Assets/Tests/EditMode/OrderRequestValidatorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 698d4d48-2fb2-4ab6-b37b-8b9c016df080
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/OrderSystemTests.cs
+++ b/Assets/Tests/EditMode/OrderSystemTests.cs
@@ -1,4 +1,5 @@
-#if UNITY_EDITOR
+#if UNITY_INCLUDE_TESTS
+using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
 using TavernSim.Domain;
@@ -8,20 +9,87 @@ using UnityEngine;
 public class OrderSystemTests
 {
     [Test]
-    public void Enqueue_Progress_ConsumeReady()
+    public void OrdersAdvancePerPrepArea()
     {
         var orders = new OrderSystem();
+        orders.SetKitchenStations(1);
+        orders.SetBarStations(1);
+
+        var kitchenRecipe = CreateRecipe("stew", "Ensopado", 0.1f);
+        var barRecipe = CreateRecipe("beer", "Cerveja", 0.1f);
+
+        orders.EnqueueOrder(1, kitchenRecipe);
+        orders.EnqueueOrder(2, barRecipe);
+
+        orders.Tick(0.05f);
+        var snapshot = orders.GetOrders();
+        Assert.AreEqual(2, snapshot.Count);
+        Assert.IsTrue(snapshot.Any(o => o.TableId == 1 && o.Area == PrepArea.Kitchen));
+        Assert.IsTrue(snapshot.Any(o => o.TableId == 2 && o.Area == PrepArea.Bar));
+
+        orders.Tick(0.1f);
+
+        Assert.IsTrue(orders.TryConsumeReadyOrder(1, out var kitchenReady, out var kitchenArea));
+        Assert.AreSame(kitchenRecipe, kitchenReady);
+        Assert.AreEqual(PrepArea.Kitchen, kitchenArea);
+
+        Assert.IsTrue(orders.TryConsumeReadyOrder(2, out var barReady, out var barArea));
+        Assert.AreSame(barRecipe, barReady);
+        Assert.AreEqual(PrepArea.Bar, barArea);
+    }
+
+    [Test]
+    public void RespectsStationLimits()
+    {
+        var orders = new OrderSystem();
+        orders.SetKitchenStations(1);
+        orders.SetBarStations(1);
+
+        var first = CreateRecipe("stewA", "Ensopado A", 0.2f);
+        var second = CreateRecipe("stewB", "Ensopado B", 0.2f);
+
+        orders.EnqueueOrder(1, first);
+        orders.EnqueueOrder(2, second);
+        orders.Tick(0f);
+
+        var snapshot = orders.GetOrders();
+        var active = snapshot.First(o => o.TableId == 1);
+        var queued = snapshot.First(o => o.TableId == 2);
+        Assert.AreEqual(OrderState.InPreparation, active.State);
+        Assert.AreEqual(OrderState.Queued, queued.State);
+
+        orders.Tick(0.25f);
+        Assert.IsTrue(orders.TryConsumeReadyOrder(1, out _, out _));
+
+        orders.Tick(0f);
+        snapshot = orders.GetOrders();
+        var promoted = snapshot.First(o => o.TableId == 2);
+        Assert.AreEqual(OrderState.InPreparation, promoted.State);
+    }
+
+    [Test]
+    public void TryConsumeReadyOrderMatchesTable()
+    {
+        var orders = new OrderSystem();
+        orders.SetKitchenStations(1);
+        var soup = CreateRecipe("soup", "Sopa", 0.05f);
+
+        orders.EnqueueOrder(1, soup);
+        orders.Tick(0.1f);
+
+        Assert.IsFalse(orders.TryConsumeReadyOrder(2, out _, out _));
+        Assert.IsTrue(orders.TryConsumeReadyOrder(1, out var recipe, out var area));
+        Assert.AreSame(soup, recipe);
+        Assert.AreEqual(PrepArea.Kitchen, area);
+    }
+
+    private static RecipeSO CreateRecipe(string id, string name, float prepTime)
+    {
         var recipe = ScriptableObject.CreateInstance<RecipeSO>();
-
-        // Configure the dummy recipe's prep time for a quick turnaround in tests.
-        var prepField = typeof(RecipeSO).GetField("prepTime", BindingFlags.Instance | BindingFlags.NonPublic);
-        prepField?.SetValue(recipe, 0.01f);
-
-        orders.EnqueueOrder(tableId: 1, recipe: recipe);
-        orders.Tick(0.02f);
-
-        Assert.IsTrue(orders.TryConsumeReadyOrder(1, out var delivered));
-        Assert.NotNull(delivered);
+        typeof(RecipeSO).GetField("id", BindingFlags.Instance | BindingFlags.NonPublic)?.SetValue(recipe, id);
+        typeof(RecipeSO).GetField("displayName", BindingFlags.Instance | BindingFlags.NonPublic)?.SetValue(recipe, name);
+        typeof(RecipeSO).GetField("prepTime", BindingFlags.Instance | BindingFlags.NonPublic)?.SetValue(recipe, prepTime);
+        return recipe;
     }
 }
 #endif

--- a/Assets/UI/HUDController.cs
+++ b/Assets/UI/HUDController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UIElements;
@@ -33,6 +34,9 @@ namespace TavernSim.UI
         private Button _saveButton;
         private Button _loadButton;
         private Button _buildToggleButton;
+        private VisualElement _hireControls;
+        private Button _hireWaiterButton;
+        private Button _hireCookButton;
         private VisualElement _buildMenu;
         private readonly List<Label> _orderEntries = new List<Label>(16);
         private readonly List<Button> _buildOptionButtons = new List<Button>();
@@ -42,12 +46,19 @@ namespace TavernSim.UI
 
         private SelectionService _selectionService;
         private GridPlacer _gridPlacer;
+        private IEventBus _eventBus;
+
+        public event Action HireWaiterRequested;
+        public event Action HireCookRequested;
 
         private static readonly BuildOption[] BuildOptions =
         {
             new BuildOption("buildSmallTableBtn", "Mesa pequena", GridPlacer.PlaceableKind.SmallTable),
             new BuildOption("buildLargeTableBtn", "Mesa grande", GridPlacer.PlaceableKind.LargeTable),
-            new BuildOption("buildDecorBtn", "Planta", GridPlacer.PlaceableKind.Decoration)
+            new BuildOption("buildDecorBtn", "Planta", GridPlacer.PlaceableKind.Decoration),
+            new BuildOption("buildKitchenStationBtn", "Estação de cozinha", GridPlacer.PlaceableKind.KitchenStation),
+            new BuildOption("buildBarCounterBtn", "Balcão do bar", GridPlacer.PlaceableKind.BarCounter),
+            new BuildOption("buildPickupPointBtn", "Ponto de retirada", GridPlacer.PlaceableKind.PickupPoint)
         };
 
         public void Initialize(EconomySystem economySystem, OrderSystem orderSystem)
@@ -91,6 +102,18 @@ namespace TavernSim.UI
             {
                 HookEvents();
             }
+        }
+
+        public void BindEventBus(IEventBus eventBus)
+        {
+            _eventBus = eventBus;
+            var toastController = GetComponent<HudToastController>();
+            toastController?.Initialize(_eventBus);
+        }
+
+        public void PublishEvent(GameEvent gameEvent)
+        {
+            _eventBus?.Publish(gameEvent);
         }
 
         public void SetVisualConfig(HUDVisualConfig config)
@@ -216,11 +239,27 @@ namespace TavernSim.UI
             _saveButton = rootElement.Q<Button>("saveBtn") ?? CreateButton(layoutRoot, "saveBtn", "Save (F5)");
             _loadButton = rootElement.Q<Button>("loadBtn") ?? CreateButton(layoutRoot, "loadBtn", "Load (F9)");
             _selectionLabel = rootElement.Q<Label>("selectionLabel") ?? CreateLabel(layoutRoot, "selectionLabel", "Selecionado: Nenhum");
+            _hireControls = rootElement.Q<VisualElement>("hireControls") ?? CreateHireControls(layoutRoot);
+            _hireWaiterButton = rootElement.Q<Button>("hireWaiterBtn") ?? CreateButton(_hireControls, "hireWaiterBtn", "Contratar garçom");
+            _hireCookButton = rootElement.Q<Button>("hireCookBtn") ?? CreateButton(_hireControls, "hireCookBtn", "Contratar cozinheiro");
+            _hireWaiterButton?.AddToClassList("hud-button");
+            _hireCookButton?.AddToClassList("hud-button");
+            _hireCookButton?.AddToClassList("stacked");
+            if (_hireWaiterButton != null)
+            {
+                _hireWaiterButton.style.marginTop = 0f;
+            }
             _buildToggleButton = rootElement.Q<Button>("buildToggleBtn") ?? CreateButton(layoutRoot, "buildToggleBtn", "Construir");
             _buildMenu = rootElement.Q<VisualElement>("buildMenu") ?? CreateBuildMenu(layoutRoot);
 
             CreateBuildButtons();
             SetBuildMenuVisible(false);
+
+            var menuController = GetComponent<MenuController>();
+            menuController?.RebuildMenu(rootElement);
+
+            var toastController = GetComponent<HudToastController>();
+            toastController?.AttachTo(rootElement);
         }
 
         private void HookEvents()
@@ -255,6 +294,18 @@ namespace TavernSim.UI
             {
                 _buildToggleButton.clicked -= ToggleBuildMenu;
                 _buildToggleButton.clicked += ToggleBuildMenu;
+            }
+
+            if (_hireWaiterButton != null)
+            {
+                _hireWaiterButton.clicked -= OnHireWaiterClicked;
+                _hireWaiterButton.clicked += OnHireWaiterClicked;
+            }
+
+            if (_hireCookButton != null)
+            {
+                _hireCookButton.clicked -= OnHireCookClicked;
+                _hireCookButton.clicked += OnHireCookClicked;
             }
 
             if (_selectionService != null)
@@ -301,6 +352,16 @@ namespace TavernSim.UI
                 _buildToggleButton.clicked -= ToggleBuildMenu;
             }
 
+            if (_hireWaiterButton != null)
+            {
+                _hireWaiterButton.clicked -= OnHireWaiterClicked;
+            }
+
+            if (_hireCookButton != null)
+            {
+                _hireCookButton.clicked -= OnHireCookClicked;
+            }
+
             if (_selectionService != null)
             {
                 _selectionService.SelectionChanged -= OnSelectionChanged;
@@ -338,12 +399,38 @@ namespace TavernSim.UI
 
             for (int i = 0; i < orders.Count; i++)
             {
+                var order = orders[i];
+                var recipeName = order.Recipe != null ? order.Recipe.DisplayName : "Desconhecido";
+                var areaLabel = order.Area.GetDisplayName();
+                var status = order.IsReady ? "Pronto" : order.State == OrderState.Queued ? "Fila" : $"{order.Remaining:0.0}s";
                 var label = new Label
                 {
-                    text = $"Table {orders[i].TableId} - {orders[i].Recipe?.DisplayName ?? "Unknown"} ({orders[i].Remaining:0.0}s)"
+                    text = $"Mesa {order.TableId} - {recipeName} ({areaLabel}) [{status}]"
                 };
+                ApplyOrderStyle(label, order);
                 _ordersScroll.contentContainer.Add(label);
                 _orderEntries.Add(label);
+            }
+        }
+
+        private static void ApplyOrderStyle(Label label, Order order)
+        {
+            if (label == null || order == null)
+            {
+                return;
+            }
+
+            if (order.IsReady)
+            {
+                label.style.color = new StyleColor(new Color(0.56f, 0.87f, 0.3f));
+            }
+            else if (order.State == OrderState.Queued)
+            {
+                label.style.color = new StyleColor(new Color(0.7f, 0.7f, 0.7f));
+            }
+            else
+            {
+                label.style.color = new StyleColor(Color.white);
             }
         }
 
@@ -375,6 +462,16 @@ namespace TavernSim.UI
         private void ToggleBuildMenu()
         {
             SetBuildMenuVisible(!_buildMenuVisible);
+        }
+
+        private void OnHireWaiterClicked()
+        {
+            HireWaiterRequested?.Invoke();
+        }
+
+        private void OnHireCookClicked()
+        {
+            HireCookRequested?.Invoke();
         }
 
         private void SetBuildMenuVisible(bool visible)
@@ -541,6 +638,15 @@ namespace TavernSim.UI
         private static VisualElement CreateBuildMenu(VisualElement root)
         {
             var container = new VisualElement { name = "buildMenu" };
+            root.Add(container);
+            return container;
+        }
+
+        private static VisualElement CreateHireControls(VisualElement root)
+        {
+            var container = new VisualElement { name = "hireControls" };
+            container.AddToClassList("hire-controls");
+            container.AddToClassList("stacked");
             root.Add(container);
             return container;
         }

--- a/Assets/UI/HudToastController.cs
+++ b/Assets/UI/HudToastController.cs
@@ -1,0 +1,241 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UIElements;
+using TavernSim.Core;
+
+namespace TavernSim.UI
+{
+    [RequireComponent(typeof(UIDocument))]
+    public sealed class HudToastController : MonoBehaviour, IEventSink
+    {
+        [SerializeField] private float toastDuration = 4f;
+        [SerializeField] private int maxToasts = 4;
+
+        private UIDocument _document;
+        private IEventBus _eventBus;
+        private VisualElement _root;
+        private VisualElement _container;
+        private readonly List<ToastEntry> _entries = new List<ToastEntry>(8);
+
+        private void Awake()
+        {
+            _document = GetComponent<UIDocument>();
+        }
+
+        private void OnEnable()
+        {
+            if (_eventBus != null)
+            {
+                _eventBus.Subscribe(this);
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (_eventBus != null)
+            {
+                _eventBus.Unsubscribe(this);
+            }
+
+            ClearToasts();
+        }
+
+        public void Initialize(IEventBus eventBus)
+        {
+            if (_eventBus == eventBus)
+            {
+                return;
+            }
+
+            if (isActiveAndEnabled && _eventBus != null)
+            {
+                _eventBus.Unsubscribe(this);
+            }
+
+            _eventBus = eventBus;
+
+            if (isActiveAndEnabled && _eventBus != null)
+            {
+                _eventBus.Subscribe(this);
+            }
+        }
+
+        public void AttachTo(VisualElement root)
+        {
+            _root = root;
+            EnsureContainer();
+        }
+
+        public void Receive(GameEvent gameEvent)
+        {
+            EnsureContainer();
+            if (_container == null)
+            {
+                return;
+            }
+
+            var element = CreateToastElement(gameEvent);
+            var coroutine = StartCoroutine(AutoRemove(element, toastDuration));
+            _entries.Add(new ToastEntry(element, coroutine));
+            TrimToasts();
+        }
+
+        private void EnsureContainer()
+        {
+            if (_root == null)
+            {
+                _root = _document != null ? _document.rootVisualElement : null;
+                if (_root == null)
+                {
+                    return;
+                }
+            }
+
+            if (_container != null && _container.panel == _root.panel)
+            {
+                return;
+            }
+
+            _container = _root.Q<VisualElement>("hudToastContainer");
+            if (_container == null)
+            {
+                _container = new VisualElement
+                {
+                    name = "hudToastContainer",
+                    style =
+                    {
+                        position = Position.Absolute,
+                        bottom = 16f,
+                        left = 16f,
+                        flexDirection = FlexDirection.Column,
+                        maxWidth = 360f,
+                        unityFontStyleAndWeight = FontStyle.Normal
+                    }
+                };
+                _root.Add(_container);
+            }
+
+            _container.style.position = Position.Absolute;
+            _container.style.bottom = 16f;
+            _container.style.left = 16f;
+            _container.style.flexDirection = FlexDirection.Column;
+            _container.style.gap = 6f;
+            _container.style.maxWidth = 360f;
+        }
+
+        private VisualElement CreateToastElement(GameEvent gameEvent)
+        {
+            var toast = new VisualElement
+            {
+                style =
+                {
+                    backgroundColor = new StyleColor(GetBackgroundColor(gameEvent.Severity)),
+                    paddingLeft = 12f,
+                    paddingRight = 12f,
+                    paddingTop = 6f,
+                    paddingBottom = 6f,
+                    marginBottom = 4f,
+                    unityTextAlign = TextAnchor.MiddleLeft,
+                    borderRadius = 6f,
+                    opacity = 0.95f
+                }
+            };
+
+            var label = new Label(gameEvent.Message)
+            {
+                style =
+                {
+                    unityTextAlign = TextAnchor.MiddleLeft,
+                    whiteSpace = WhiteSpace.Normal,
+                    color = new StyleColor(Color.white)
+                }
+            };
+
+            toast.Add(label);
+            _container.Add(toast);
+            return toast;
+        }
+
+        private void TrimToasts()
+        {
+            while (_entries.Count > maxToasts && _entries.Count > 0)
+            {
+                var entry = _entries[0];
+                _entries.RemoveAt(0);
+                if (entry.Coroutine != null)
+                {
+                    StopCoroutine(entry.Coroutine);
+                }
+
+                entry.Element.RemoveFromHierarchy();
+            }
+        }
+
+        private IEnumerator AutoRemove(VisualElement element, float duration)
+        {
+            yield return new WaitForSeconds(duration);
+            RemoveToast(element);
+        }
+
+        private void RemoveToast(VisualElement element)
+        {
+            for (int i = 0; i < _entries.Count; i++)
+            {
+                if (_entries[i].Element == element)
+                {
+                    if (_entries[i].Coroutine != null)
+                    {
+                        StopCoroutine(_entries[i].Coroutine);
+                    }
+
+                    _entries.RemoveAt(i);
+                    break;
+                }
+            }
+
+            element.RemoveFromHierarchy();
+        }
+
+        private void ClearToasts()
+        {
+            for (int i = 0; i < _entries.Count; i++)
+            {
+                var entry = _entries[i];
+                if (entry.Coroutine != null)
+                {
+                    StopCoroutine(entry.Coroutine);
+                }
+
+                entry.Element.RemoveFromHierarchy();
+            }
+
+            _entries.Clear();
+        }
+
+        private static Color GetBackgroundColor(GameEventSeverity severity)
+        {
+            switch (severity)
+            {
+                case GameEventSeverity.Warning:
+                    return new Color(0.8f, 0.52f, 0.16f, 0.92f);
+                case GameEventSeverity.Error:
+                    return new Color(0.74f, 0.18f, 0.18f, 0.92f);
+                default:
+                    return new Color(0.16f, 0.52f, 0.8f, 0.92f);
+            }
+        }
+
+        private readonly struct ToastEntry
+        {
+            public ToastEntry(VisualElement element, Coroutine coroutine)
+            {
+                Element = element;
+                Coroutine = coroutine;
+            }
+
+            public VisualElement Element { get; }
+            public Coroutine Coroutine { get; }
+        }
+    }
+}

--- a/Assets/UI/HudToastController.cs.meta
+++ b/Assets/UI/HudToastController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a95c80db-67a5-4705-89a0-b2fa178d50fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UI/MenuController.cs
+++ b/Assets/UI/MenuController.cs
@@ -1,0 +1,161 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UIElements;
+using TavernSim.Domain;
+using TavernSim.Simulation.Systems;
+
+namespace TavernSim.UI
+{
+    [RequireComponent(typeof(UIDocument))]
+    public sealed class MenuController : MonoBehaviour, IMenuPolicy
+    {
+        private const string MenuFoldoutName = "menuFoldout";
+        private const string PlayerPrefsPrefix = "TavernSim.Menu.";
+
+        private Catalog _catalog;
+        private UIDocument _document;
+        private Foldout _foldout;
+        private readonly Dictionary<string, bool> _allowLookup = new Dictionary<string, bool>();
+        private readonly Dictionary<string, Toggle> _toggleLookup = new Dictionary<string, Toggle>();
+
+        public void Initialize(Catalog catalog)
+        {
+            _catalog = catalog;
+            BuildStateCache();
+            RebuildMenu(GetRoot());
+        }
+
+        public void RebuildMenu(VisualElement root)
+        {
+            _document ??= GetComponent<UIDocument>();
+            if (root == null)
+            {
+                root = GetRoot();
+            }
+
+            if (root == null)
+            {
+                return;
+            }
+
+            _foldout = root.Q<Foldout>(MenuFoldoutName);
+            if (_foldout != null)
+            {
+                _foldout.Clear();
+            }
+            else
+            {
+                _foldout = new Foldout
+                {
+                    text = "Menu",
+                    name = MenuFoldoutName,
+                    value = true,
+                    style =
+                    {
+                        marginTop = 8f,
+                        unityFontStyleAndWeight = FontStyle.Bold
+                    }
+                };
+                root.Add(_foldout);
+            }
+
+            _toggleLookup.Clear();
+            if (_catalog == null)
+            {
+                return;
+            }
+
+            foreach (var pair in _catalog.Recipes)
+            {
+                var recipe = pair.Value;
+                if (recipe == null)
+                {
+                    continue;
+                }
+
+                var allowed = GetState(recipe.Id);
+                var toggle = new Toggle(recipe.DisplayName)
+                {
+                    value = allowed,
+                    tooltip = recipe.Id
+                };
+                toggle.RegisterValueChangedCallback(evt => OnToggleChanged(recipe, evt.newValue));
+                _foldout.Add(toggle);
+                _toggleLookup[recipe.Id] = toggle;
+            }
+        }
+
+        public bool IsAllowed(RecipeSO recipe)
+        {
+            if (recipe == null)
+            {
+                return false;
+            }
+
+            if (_allowLookup.TryGetValue(recipe.Id, out var allowed))
+            {
+                return allowed;
+            }
+
+            return true;
+        }
+
+        private VisualElement GetRoot()
+        {
+            if (_document == null)
+            {
+                _document = GetComponent<UIDocument>();
+            }
+
+            return _document != null ? _document.rootVisualElement : null;
+        }
+
+        private void BuildStateCache()
+        {
+            _allowLookup.Clear();
+            if (_catalog == null)
+            {
+                return;
+            }
+
+            foreach (var pair in _catalog.Recipes)
+            {
+                var recipe = pair.Value;
+                if (recipe == null || string.IsNullOrEmpty(recipe.Id))
+                {
+                    continue;
+                }
+
+                _allowLookup[recipe.Id] = PlayerPrefs.GetInt(PlayerPrefsPrefix + recipe.Id, 1) != 0;
+            }
+        }
+
+        private bool GetState(string recipeId)
+        {
+            if (string.IsNullOrEmpty(recipeId))
+            {
+                return true;
+            }
+
+            if (_allowLookup.TryGetValue(recipeId, out var allowed))
+            {
+                return allowed;
+            }
+
+            _allowLookup[recipeId] = true;
+            return true;
+        }
+
+        private void OnToggleChanged(RecipeSO recipe, bool allowed)
+        {
+            if (recipe == null || string.IsNullOrEmpty(recipe.Id))
+            {
+                return;
+            }
+
+            _allowLookup[recipe.Id] = allowed;
+            PlayerPrefs.SetInt(PlayerPrefsPrefix + recipe.Id, allowed ? 1 : 0);
+            PlayerPrefs.Save();
+        }
+    }
+}

--- a/Assets/UI/MenuController.cs.meta
+++ b/Assets/UI/MenuController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d16e346-13fb-43df-8e65-83a848ae1df6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UI/USS/HUD.uss
+++ b/Assets/UI/USS/HUD.uss
@@ -46,6 +46,15 @@
     flex-direction: column;
 }
 
+.hire-controls {
+    margin-top: 6px;
+    flex-direction: column;
+}
+
+.hire-controls > .hud-button {
+    margin-top: 4px;
+}
+
 .build-menu {
     background-color: rgba(255, 255, 255, 0.05);
     border-radius: 4px;

--- a/Assets/UI/UXML/HUD.uxml
+++ b/Assets/UI/UXML/HUD.uxml
@@ -16,6 +16,10 @@
       <ui:Button name="loadBtn" class="hud-button hud-button--spaced" text="Load (F9)" />
     </ui:VisualElement>
     <ui:Label name="selectionLabel" class="stat selection stacked" text="Selecionado: Nenhum" />
+    <ui:VisualElement name="hireControls" class="hire-controls stacked">
+      <ui:Button name="hireWaiterBtn" class="hud-button" text="Contratar garçom" />
+      <ui:Button name="hireCookBtn" class="hud-button stacked" text="Contratar cozinheiro" />
+    </ui:VisualElement>
     <ui:VisualElement name="buildControls" class="build-controls stacked">
       <ui:Button name="buildToggleBtn" text="Construir" />
       <ui:VisualElement name="buildMenu" class="build-menu stacked" />

--- a/Tools/OfflineTests/OfflineTests.csproj
+++ b/Tools/OfflineTests/OfflineTests.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <DefineConstants>UNITY_EDITOR;UNITY_2022_3</DefineConstants>
+    <DefineConstants>UNITY_EDITOR;UNITY_INCLUDE_TESTS;UNITY_2022_3</DefineConstants>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
 
@@ -20,11 +20,17 @@
     <Compile Include="../../Assets/Core/Simulation/Simulation.cs">
       <Link>GameCode/Core/Simulation/Simulation.cs</Link>
     </Compile>
+    <Compile Include="../../Assets/Core/GameEvents.cs">
+      <Link>GameCode/Core/GameEvents.cs</Link>
+    </Compile>
     <Compile Include="../../Assets/Simulation/Systems/EconomySystem.cs">
       <Link>GameCode/Simulation/Systems/EconomySystem.cs</Link>
     </Compile>
     <Compile Include="../../Assets/Simulation/Systems/OrderSystem.cs">
       <Link>GameCode/Simulation/Systems/OrderSystem.cs</Link>
+    </Compile>
+    <Compile Include="../../Assets/Simulation/Systems/OrderRequestValidator.cs">
+      <Link>GameCode/Simulation/Systems/OrderRequestValidator.cs</Link>
     </Compile>
     <Compile Include="../../Assets/Domain/ItemSO.cs">
       <Link>GameCode/Domain/ItemSO.cs</Link>
@@ -37,6 +43,9 @@
     </Compile>
     <Compile Include="../../Assets/Tests/EditMode/OrderSystemTests.cs">
       <Link>Tests/EditMode/OrderSystemTests.cs</Link>
+    </Compile>
+    <Compile Include="../../Assets/Tests/EditMode/OrderRequestValidatorTests.cs">
+      <Link>Tests/EditMode/OrderRequestValidatorTests.cs</Link>
     </Compile>
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- expose the HUD event bus types under the legacy `TavernSim.Core.Events` namespace to keep runtime scripts compiling
- wrap edit-mode test scripts in `UNITY_INCLUDE_TESTS` so they only build with the Unity test assemblies and mirror the new symbol in the offline harness

## Testing
- `dotnet test Tools/OfflineTests/OfflineTests.csproj` *(fails: dotnet CLI unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d00c4dfd7c8333a7f21ec90925199e