### PR TITLE
Add selection HUD and reputation tracking

### DIFF
--- a/Assets/Agents/Bartender.cs
+++ b/Assets/Agents/Bartender.cs
@@ -1,12 +1,34 @@
 using UnityEngine;
 using UnityEngine.AI;
+using TavernSim.Core;
 
 namespace TavernSim.Agents
 {
     [RequireComponent(typeof(NavMeshAgent))]
-    public sealed class Bartender : MonoBehaviour
+    public sealed class Bartender : MonoBehaviour, ISelectable
     {
+        [SerializeField] private AgentIntentDisplay intentDisplay;
+        [SerializeField] private float salary = 28f;
+
         public NavMeshAgent Agent { get; private set; }
-        void Awake() => Agent = GetComponent<NavMeshAgent>();
+
+        public string DisplayName => "Bartender";
+
+        public Transform Transform => transform;
+
+        public float Salary => salary;
+
+        public float MovementSpeed => Agent != null ? Agent.speed : 0f;
+
+        public string Status => intentDisplay != null ? intentDisplay.CurrentIntent : string.Empty;
+
+        private void Awake()
+        {
+            Agent = GetComponent<NavMeshAgent>();
+            if (intentDisplay == null)
+            {
+                TryGetComponent(out intentDisplay);
+            }
+        }
     }
 }

--- a/Assets/Agents/Cook.cs
+++ b/Assets/Agents/Cook.cs
@@ -1,12 +1,34 @@
 using UnityEngine;
 using UnityEngine.AI;
+using TavernSim.Core;
 
 namespace TavernSim.Agents
 {
     [RequireComponent(typeof(NavMeshAgent))]
-    public sealed class Cook : MonoBehaviour
+    public sealed class Cook : MonoBehaviour, ISelectable
     {
+        [SerializeField] private AgentIntentDisplay intentDisplay;
+        [SerializeField] private float salary = 30f;
+
         public NavMeshAgent Agent { get; private set; }
-        void Awake() => Agent = GetComponent<NavMeshAgent>();
+
+        public string DisplayName => "Cozinheiro";
+
+        public Transform Transform => transform;
+
+        public float Salary => salary;
+
+        public float MovementSpeed => Agent != null ? Agent.speed : 0f;
+
+        public string Status => intentDisplay != null ? intentDisplay.CurrentIntent : string.Empty;
+
+        private void Awake()
+        {
+            Agent = GetComponent<NavMeshAgent>();
+            if (intentDisplay == null)
+            {
+                TryGetComponent(out intentDisplay);
+            }
+        }
     }
 }

--- a/Assets/Agents/Customer.cs
+++ b/Assets/Agents/Customer.cs
@@ -14,11 +14,22 @@ namespace TavernSim.Agents
         [SerializeField] private AgentIntentDisplay intentDisplay;
 
         private NavMeshAgent _agent;
+        private string _assignedName;
+        private int _gold;
+        private float _patience;
 
         public NavMeshAgent Agent => _agent;
         public Animator Animator => animator;
 
         public string DisplayName => "Cliente";
+
+        public string FullName => string.IsNullOrEmpty(_assignedName) ? gameObject.name : _assignedName;
+
+        public int Gold => _gold;
+
+        public float Patience => _patience;
+
+        public string Status => intentDisplay != null ? intentDisplay.CurrentIntent : string.Empty;
 
         public Transform Transform => transform;
 
@@ -102,6 +113,13 @@ namespace TavernSim.Agents
             }
 
             intentDisplay?.SetIntent(text);
+        }
+
+        public void ApplyProfile(string name, int gold, float patience)
+        {
+            _assignedName = name;
+            _gold = gold;
+            _patience = patience;
         }
     }
 }

--- a/Assets/Agents/CustomerSpawner.cs
+++ b/Assets/Agents/CustomerSpawner.cs
@@ -67,6 +67,11 @@ namespace TavernSim.Agents
                 return;
             }
 
+            if (!_agentSystem.HasAvailableSeating() || !_agentSystem.HasActiveWaiter())
+            {
+                return;
+            }
+
             _timer += deltaTime;
             CleanupInactive();
 

--- a/Assets/Agents/Waiter.cs
+++ b/Assets/Agents/Waiter.cs
@@ -27,7 +27,7 @@ namespace TavernSim.Agents
             _agent = GetComponent<NavMeshAgent>();
             _agent.angularSpeed = 720f;
             _agent.acceleration = 36f;
-            _agent.stoppingDistance = 0.05f;
+            _agent.stoppingDistance = 0.35f;
 
             if (intentDisplay == null)
             {

--- a/Assets/Agents/Waiter.cs
+++ b/Assets/Agents/Waiter.cs
@@ -8,10 +8,17 @@ namespace TavernSim.Agents
     public sealed class Waiter : MonoBehaviour, ISelectable
     {
         [SerializeField] private AgentIntentDisplay intentDisplay;
+        [SerializeField] private float salary = 25f;
 
         private NavMeshAgent _agent;
 
         public string DisplayName => "Garçom";
+
+        public string Status => intentDisplay != null ? intentDisplay.CurrentIntent : string.Empty;
+
+        public float Salary => salary;
+
+        public float MovementSpeed => _agent != null ? _agent.speed : 0f;
 
         public Transform Transform => transform;
 

--- a/Assets/Building/BuildGridVisualizer.cs
+++ b/Assets/Building/BuildGridVisualizer.cs
@@ -1,0 +1,231 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace TavernSim.Building
+{
+    /// <summary>
+    /// Draws a simple grid using line renderers to help players visualize build placement cells.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class BuildGridVisualizer : MonoBehaviour
+    {
+        [SerializeField] private int gridExtent = 12;
+        [SerializeField] private float gridSize = 1f;
+        [SerializeField] private float lineWidth = 0.02f;
+        [SerializeField] private float lineHeight = 0.02f;
+        [SerializeField] private Color lineColor = new Color(0.3f, 0.8f, 1f, 0.35f);
+
+        private readonly List<LineRenderer> _lines = new List<LineRenderer>();
+        private Material _lineMaterial;
+
+        private void Awake()
+        {
+            EnsureMaterial();
+            RebuildLines();
+            ApplySettings();
+            UpdateLinePositions();
+        }
+
+        private void OnEnable()
+        {
+            ApplySettings();
+            SetLinesEnabled(true);
+        }
+
+        private void OnDisable()
+        {
+            SetLinesEnabled(false);
+        }
+
+        private void OnValidate()
+        {
+            gridExtent = Mathf.Max(1, gridExtent);
+            gridSize = Mathf.Max(0.1f, gridSize);
+            lineWidth = Mathf.Clamp(lineWidth, 0.001f, 0.25f);
+            lineHeight = Mathf.Max(0.001f, lineHeight);
+
+            EnsureMaterial();
+            RebuildLines();
+            ApplySettings();
+            UpdateLinePositions();
+        }
+
+        private void OnDestroy()
+        {
+            if (_lineMaterial != null)
+            {
+                if (Application.isPlaying)
+                {
+                    Destroy(_lineMaterial);
+                }
+                else
+                {
+                    DestroyImmediate(_lineMaterial);
+                }
+
+                _lineMaterial = null;
+            }
+        }
+
+        /// <summary>Adjusts the grid step to match the placer grid size.</summary>
+        public void SetGridSize(float size)
+        {
+            size = Mathf.Max(0.1f, size);
+            if (Mathf.Approximately(gridSize, size))
+            {
+                return;
+            }
+
+            gridSize = size;
+            UpdateLinePositions();
+        }
+
+        /// <summary>Shows or hides the grid object.</summary>
+        public void SetVisible(bool visible)
+        {
+            if (gameObject.activeSelf == visible)
+            {
+                return;
+            }
+
+            gameObject.SetActive(visible);
+        }
+
+        private void EnsureMaterial()
+        {
+            if (_lineMaterial != null)
+            {
+                _lineMaterial.color = lineColor;
+                return;
+            }
+
+            var shader = Shader.Find("Sprites/Default");
+            if (shader == null)
+            {
+                shader = Shader.Find("Unlit/Color");
+            }
+
+            if (shader == null)
+            {
+                return;
+            }
+
+            _lineMaterial = new Material(shader)
+            {
+                color = lineColor,
+                renderQueue = 5000,
+                hideFlags = HideFlags.HideAndDontSave
+            };
+        }
+
+        private void RebuildLines()
+        {
+            int targetCount = (gridExtent * 2 + 1) * 2;
+            while (_lines.Count < targetCount)
+            {
+                var lineObject = new GameObject("GridLine")
+                {
+                    hideFlags = HideFlags.HideAndDontSave
+                };
+                lineObject.transform.SetParent(transform, false);
+
+                var lineRenderer = lineObject.AddComponent<LineRenderer>();
+                lineRenderer.useWorldSpace = false;
+                lineRenderer.positionCount = 2;
+                lineRenderer.loop = false;
+                lineRenderer.textureMode = LineTextureMode.Stretch;
+                _lines.Add(lineRenderer);
+            }
+
+            while (_lines.Count > targetCount)
+            {
+                int index = _lines.Count - 1;
+                var line = _lines[index];
+                _lines.RemoveAt(index);
+                if (line != null)
+                {
+                    if (Application.isPlaying)
+                    {
+                        Destroy(line.gameObject);
+                    }
+                    else
+                    {
+                        DestroyImmediate(line.gameObject);
+                    }
+                }
+            }
+        }
+
+        private void ApplySettings()
+        {
+            EnsureMaterial();
+            foreach (var line in _lines)
+            {
+                if (line == null)
+                {
+                    continue;
+                }
+
+                line.startWidth = lineWidth;
+                line.endWidth = lineWidth;
+                line.startColor = lineColor;
+                line.endColor = lineColor;
+                line.receiveShadows = false;
+                line.shadowCastingMode = ShadowCastingMode.Off;
+                line.alignment = LineAlignment.View;
+
+                if (_lineMaterial != null)
+                {
+                    line.sharedMaterial = _lineMaterial;
+                }
+            }
+        }
+
+        private void UpdateLinePositions()
+        {
+            if (_lines.Count == 0)
+            {
+                return;
+            }
+
+            float min = -gridExtent * gridSize;
+            float max = gridExtent * gridSize;
+            float y = lineHeight;
+            int index = 0;
+
+            for (int x = -gridExtent; x <= gridExtent; x++)
+            {
+                float pos = x * gridSize;
+                var line = _lines[index++];
+                if (line != null)
+                {
+                    line.SetPosition(0, new Vector3(pos, y, min));
+                    line.SetPosition(1, new Vector3(pos, y, max));
+                }
+            }
+
+            for (int z = -gridExtent; z <= gridExtent; z++)
+            {
+                float pos = z * gridSize;
+                var line = _lines[index++];
+                if (line != null)
+                {
+                    line.SetPosition(0, new Vector3(min, y, pos));
+                    line.SetPosition(1, new Vector3(max, y, pos));
+                }
+            }
+        }
+
+        private void SetLinesEnabled(bool enabled)
+        {
+            foreach (var line in _lines)
+            {
+                if (line != null)
+                {
+                    line.enabled = enabled;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Building/GridPlacer.cs
+++ b/Assets/Building/GridPlacer.cs
@@ -58,6 +58,7 @@ namespace TavernSim.Building
         private bool _canAffordPreview = true;
         private Collider _lastSurfaceCollider;
         private readonly Collider[] _overlapResults = new Collider[32];
+        private bool _pointerOverUI;
 
         public event Action<PlaceableKind> PlacementModeChanged;
 
@@ -123,6 +124,12 @@ namespace TavernSim.Building
             if (!TryGetPointerData(out var screenPoint, out var leftClick, out var rightClick, out var cancelPressed))
             {
                 return;
+            }
+
+            if (_pointerOverUI)
+            {
+                leftClick = false;
+                rightClick = false;
             }
 
             if (HasActivePlacement)
@@ -209,6 +216,11 @@ namespace TavernSim.Building
         public void ExitBuildMode()
         {
             SetBuildMode(false);
+        }
+
+        public void SetPointerOverUI(bool isOverUI)
+        {
+            _pointerOverUI = isOverUI;
         }
 
         public float GetPlacementCost(PlaceableKind kind)

--- a/Assets/Building/GridPlacer.cs
+++ b/Assets/Building/GridPlacer.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine;
+using UnityEngine.Rendering;
 using TavernSim.Core;
 using TavernSim.Simulation.Models;
 using TavernSim.Simulation.Systems;
@@ -11,7 +12,8 @@ using Object = UnityEngine.Object;
 namespace TavernSim.Building
 {
     /// <summary>
-    /// Minimal grid based placement tool used for development of the MVP.
+    /// Grid based placement tool used for development of the MVP.
+    /// Adds build-mode helpers such as grid visualization and placement previews.
     /// </summary>
     public sealed class GridPlacer : MonoBehaviour
     {
@@ -33,18 +35,34 @@ namespace TavernSim.Building
         [SerializeField] private float kitchenStationCost = 420f;
         [SerializeField] private float barCounterCost = 360f;
         [SerializeField] private float pickupPointCost = 0f;
+        [Header("Build Mode")]
+        [SerializeField] private BuildGridVisualizer gridVisualizer;
+        [SerializeField] private LayerMask placementMask = ~0;
+        [SerializeField] private float previewHeight = 0.05f;
+        [SerializeField] private Color previewValidColor = new Color(0.25f, 0.8f, 0.25f, 0.35f);
+        [SerializeField] private Color previewInvalidColor = new Color(0.85f, 0.3f, 0.3f, 0.35f);
 
         private EconomySystem _economySystem;
         private SelectionService _selectionService;
         private TableRegistry _tableRegistry;
         private CleaningSystem _cleaningSystem;
         private PlaceableKind _activeKind = PlaceableKind.None;
+        private bool _buildModeActive;
+        private GameObject _previewObject;
+        private Renderer[] _previewRenderers = Array.Empty<Renderer>();
+        private Material _previewMaterial;
+        private PlaceableKind _previewKind = PlaceableKind.None;
+        private Vector3 _currentPreviewPosition;
+        private bool _hasValidPreview;
+        private bool _canAffordPreview = true;
 
-        public event System.Action<PlaceableKind> PlacementModeChanged;
+        public event Action<PlaceableKind> PlacementModeChanged;
 
         public PlaceableKind ActiveKind => _activeKind;
 
         public bool HasActivePlacement => _activeKind != PlaceableKind.None;
+
+        public bool BuildModeActive => _buildModeActive;
 
         public void Configure(
             EconomySystem economySystem,
@@ -56,6 +74,40 @@ namespace TavernSim.Building
             _selectionService = selectionService;
             _tableRegistry = tableRegistry;
             _cleaningSystem = cleaningSystem;
+
+            ApplyGridSizeToVisualizer();
+            UpdateGridVisibility();
+        }
+
+        private void Awake()
+        {
+            ApplyGridSizeToVisualizer();
+            UpdateGridVisibility();
+        }
+
+        private void OnValidate()
+        {
+            gridSize = Mathf.Max(0.1f, gridSize);
+            ApplyGridSizeToVisualizer();
+        }
+
+        private void OnDestroy()
+        {
+            DestroyPreview();
+
+            if (_previewMaterial != null)
+            {
+                if (Application.isPlaying)
+                {
+                    Destroy(_previewMaterial);
+                }
+                else
+                {
+                    DestroyImmediate(_previewMaterial);
+                }
+
+                _previewMaterial = null;
+            }
         }
 
         private void Update()
@@ -65,68 +117,49 @@ namespace TavernSim.Building
                 return;
             }
 
-#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
-            var mouse = Mouse.current;
-            var keyboard = Keyboard.current;
-            if (mouse == null)
+            if (!TryGetPointerData(out var screenPoint, out var leftClick, out var rightClick, out var cancelPressed))
             {
-                return;
-            }
-
-            if (HasActivePlacement && (mouse.rightButton.wasPressedThisFrame || (keyboard != null && keyboard.escapeKey.wasPressedThisFrame)))
-            {
-                CancelPlacement();
-                return;
-            }
-
-            if (!mouse.leftButton.wasPressedThisFrame)
-            {
-                return;
-            }
-
-            var pointerPosition = mouse.position.ReadValue();
-            var screenPoint = new Vector3(pointerPosition.x, pointerPosition.y, 0f);
-#elif ENABLE_LEGACY_INPUT_MANAGER
-            if (HasActivePlacement && (Input.GetMouseButtonDown(1) || Input.GetKeyDown(KeyCode.Escape)))
-            {
-                CancelPlacement();
-                return;
-            }
-
-            if (!Input.GetMouseButtonDown(0))
-            {
-                return;
-            }
-
-            var screenPoint = Input.mousePosition;
-#else
-            return;
-#endif
-
-            var mainCamera = Camera.main;
-            if (mainCamera == null)
-            {
-                return;
-            }
-
-            var ray = mainCamera.ScreenPointToRay(screenPoint);
-            if (!Physics.Raycast(ray, out var hit, 100f))
-            {
-                if (!HasActivePlacement)
-                {
-                    _selectionService.ClearSelection();
-                }
-
                 return;
             }
 
             if (HasActivePlacement)
             {
-                TryPlaceAt(hit.point);
+                if (rightClick || cancelPressed)
+                {
+                    ExitBuildMode();
+                    return;
+                }
+
+                UpdatePlacementPreview(screenPoint);
+
+                if (leftClick && _hasValidPreview)
+                {
+                    if (_canAffordPreview)
+                    {
+                        TryPlaceAt(_currentPreviewPosition);
+                    }
+                    else
+                    {
+                        UpdatePreviewColor(false);
+                    }
+                }
             }
             else
             {
-                SelectHit(hit.collider);
+                if (rightClick || cancelPressed)
+                {
+                    if (_buildModeActive)
+                    {
+                        SetBuildMode(false);
+                    }
+
+                    return;
+                }
+
+                if (leftClick)
+                {
+                    HandleSelection(screenPoint);
+                }
             }
         }
 
@@ -138,20 +171,41 @@ namespace TavernSim.Building
                 return;
             }
 
+            SetBuildMode(true);
             _selectionService?.ClearSelection();
             _activeKind = kind;
+            DestroyPreview();
             PlacementModeChanged?.Invoke(_activeKind);
         }
 
         public void CancelPlacement()
         {
-            if (_activeKind == PlaceableKind.None)
+            CancelPlacementInternal();
+            PlacementModeChanged?.Invoke(_activeKind);
+            UpdateGridVisibility();
+        }
+
+        public void SetBuildMode(bool active)
+        {
+            if (_buildModeActive == active)
             {
                 return;
             }
 
-            _activeKind = PlaceableKind.None;
-            PlacementModeChanged?.Invoke(_activeKind);
+            _buildModeActive = active;
+
+            if (!_buildModeActive)
+            {
+                CancelPlacementInternal();
+                PlacementModeChanged?.Invoke(_activeKind);
+            }
+
+            UpdateGridVisibility();
+        }
+
+        public void ExitBuildMode()
+        {
+            SetBuildMode(false);
         }
 
         public float GetPlacementCost(PlaceableKind kind)
@@ -179,6 +233,7 @@ namespace TavernSim.Building
             if (cost > 0f && !_economySystem.TrySpend(cost))
             {
                 Debug.LogWarning($"Not enough cash to place {_activeKind} (cost {cost:0}).");
+                UpdatePreviewColor(false);
                 return;
             }
 
@@ -232,6 +287,296 @@ namespace TavernSim.Building
             position.z = Mathf.Round(position.z / gridSize) * gridSize;
             position.y = 0f;
             return position;
+        }
+
+        private void HandleSelection(Vector3 screenPoint)
+        {
+            var mainCamera = Camera.main;
+            if (mainCamera == null)
+            {
+                return;
+            }
+
+            var ray = mainCamera.ScreenPointToRay(screenPoint);
+            if (Physics.Raycast(ray, out var hit, 200f, placementMask))
+            {
+                SelectHit(hit.collider);
+            }
+            else
+            {
+                _selectionService.ClearSelection();
+            }
+        }
+
+        private bool TryGetPointerData(out Vector3 screenPoint, out bool leftClick, out bool rightClick, out bool cancelPressed)
+        {
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+            var mouse = Mouse.current;
+            var keyboard = Keyboard.current;
+            if (mouse == null)
+            {
+                screenPoint = default;
+                leftClick = false;
+                rightClick = false;
+                cancelPressed = false;
+                return false;
+            }
+
+            var pointerPosition = mouse.position.ReadValue();
+            screenPoint = new Vector3(pointerPosition.x, pointerPosition.y, 0f);
+            leftClick = mouse.leftButton.wasPressedThisFrame;
+            rightClick = mouse.rightButton.wasPressedThisFrame;
+            cancelPressed = keyboard != null && keyboard.escapeKey.wasPressedThisFrame;
+            return true;
+#elif ENABLE_LEGACY_INPUT_MANAGER
+            screenPoint = Input.mousePosition;
+            leftClick = Input.GetMouseButtonDown(0);
+            rightClick = Input.GetMouseButtonDown(1);
+            cancelPressed = Input.GetKeyDown(KeyCode.Escape);
+            return true;
+#else
+            screenPoint = default;
+            leftClick = false;
+            rightClick = false;
+            cancelPressed = false;
+            return false;
+#endif
+        }
+
+        private void UpdatePlacementPreview(Vector3 screenPoint)
+        {
+            var mainCamera = Camera.main;
+            if (mainCamera == null)
+            {
+                HidePreview();
+                return;
+            }
+
+            var ray = mainCamera.ScreenPointToRay(screenPoint);
+            if (Physics.Raycast(ray, out var hit, 200f, placementMask))
+            {
+                _currentPreviewPosition = AlignToGrid(hit.point);
+                EnsurePreviewObject();
+
+                if (_previewObject != null)
+                {
+                    _previewObject.transform.position = _currentPreviewPosition + Vector3.up * previewHeight;
+                }
+
+                UpdatePreviewState(true);
+            }
+            else
+            {
+                UpdatePreviewState(false);
+            }
+        }
+
+        private void UpdatePreviewState(bool hasValidPosition)
+        {
+            _hasValidPreview = hasValidPosition;
+
+            if (_previewObject == null)
+            {
+                return;
+            }
+
+            if (!hasValidPosition)
+            {
+                _previewObject.SetActive(false);
+                return;
+            }
+
+            _previewObject.SetActive(true);
+            _canAffordPreview = IsPlacementAffordable(_activeKind);
+            UpdatePreviewColor(_canAffordPreview);
+        }
+
+        private bool IsPlacementAffordable(PlaceableKind kind)
+        {
+            if (_economySystem == null)
+            {
+                return true;
+            }
+
+            var cost = GetPlacementCost(kind);
+            return cost <= 0f || _economySystem.Cash >= cost - 0.001f;
+        }
+
+        private void UpdatePreviewColor(bool valid)
+        {
+            if (_previewMaterial != null)
+            {
+                _previewMaterial.color = valid ? previewValidColor : previewInvalidColor;
+            }
+        }
+
+        private void EnsurePreviewObject()
+        {
+            if (_previewObject != null && _previewKind == _activeKind)
+            {
+                return;
+            }
+
+            DestroyPreview();
+
+            if (_activeKind == PlaceableKind.None)
+            {
+                return;
+            }
+
+            _previewObject = CreatePreviewObject(_activeKind);
+            _previewKind = _activeKind;
+            _previewRenderers = _previewObject != null
+                ? _previewObject.GetComponentsInChildren<Renderer>(true)
+                : Array.Empty<Renderer>();
+
+            if (_previewMaterial == null)
+            {
+                CreatePreviewMaterial();
+            }
+
+            if (_previewRenderers != null)
+            {
+                for (int i = 0; i < _previewRenderers.Length; i++)
+                {
+                    var renderer = _previewRenderers[i];
+                    if (renderer == null)
+                    {
+                        continue;
+                    }
+
+                    renderer.shadowCastingMode = ShadowCastingMode.Off;
+                    renderer.receiveShadows = false;
+                    renderer.sharedMaterial = _previewMaterial;
+                }
+            }
+
+            UpdatePreviewColor(true);
+        }
+
+        private void CreatePreviewMaterial()
+        {
+            if (_previewMaterial != null)
+            {
+                return;
+            }
+
+            var shader = Shader.Find("Sprites/Default");
+            if (shader == null)
+            {
+                shader = Shader.Find("Universal Render Pipeline/Unlit");
+            }
+
+            if (shader == null)
+            {
+                shader = Shader.Find("Unlit/Color");
+            }
+
+            if (shader == null)
+            {
+                return;
+            }
+
+            _previewMaterial = new Material(shader)
+            {
+                color = previewValidColor,
+                renderQueue = 3000,
+                hideFlags = HideFlags.HideAndDontSave
+            };
+        }
+
+        private GameObject CreatePreviewObject(PlaceableKind kind)
+        {
+            var root = new GameObject($"{kind}Preview")
+            {
+                hideFlags = HideFlags.DontSave
+            };
+
+            var mesh = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            mesh.name = "PreviewMesh";
+            mesh.transform.SetParent(root.transform, false);
+            var scale = GetPreviewScale(kind);
+            mesh.transform.localScale = scale;
+            mesh.transform.localPosition = new Vector3(0f, scale.y * 0.5f, 0f);
+
+            if (mesh.TryGetComponent(out Collider collider))
+            {
+                Object.Destroy(collider);
+            }
+
+            return root;
+        }
+
+        private static Vector3 GetPreviewScale(PlaceableKind kind)
+        {
+            return kind switch
+            {
+                PlaceableKind.SmallTable => new Vector3(1.4f, 0.2f, 1.4f),
+                PlaceableKind.LargeTable => new Vector3(2.6f, 0.2f, 1.4f),
+                PlaceableKind.Decoration => new Vector3(0.6f, 0.2f, 0.6f),
+                PlaceableKind.KitchenStation => new Vector3(2.4f, 0.25f, 1.2f),
+                PlaceableKind.BarCounter => new Vector3(2.8f, 0.25f, 0.8f),
+                PlaceableKind.PickupPoint => new Vector3(0.6f, 0.2f, 0.6f),
+                _ => new Vector3(1f, 0.2f, 1f)
+            };
+        }
+
+        private void HidePreview()
+        {
+            _hasValidPreview = false;
+            if (_previewObject != null)
+            {
+                _previewObject.SetActive(false);
+            }
+        }
+
+        private void DestroyPreview()
+        {
+            if (_previewObject != null)
+            {
+                if (Application.isPlaying)
+                {
+                    Destroy(_previewObject);
+                }
+                else
+                {
+                    DestroyImmediate(_previewObject);
+                }
+            }
+
+            _previewObject = null;
+            _previewRenderers = Array.Empty<Renderer>();
+            _previewKind = PlaceableKind.None;
+            _hasValidPreview = false;
+            _canAffordPreview = true;
+        }
+
+        private void CancelPlacementInternal()
+        {
+            if (_activeKind == PlaceableKind.None && _previewObject == null)
+            {
+                return;
+            }
+
+            _activeKind = PlaceableKind.None;
+            DestroyPreview();
+        }
+
+        private void ApplyGridSizeToVisualizer()
+        {
+            if (gridVisualizer != null)
+            {
+                gridVisualizer.SetGridSize(gridSize);
+            }
+        }
+
+        private void UpdateGridVisibility()
+        {
+            if (gridVisualizer != null)
+            {
+                gridVisualizer.SetGridSize(gridSize);
+                gridVisualizer.SetVisible(_buildModeActive);
+            }
         }
 
         private void CreateAndRegisterTable(Vector3 position, Func<int, Vector3, Table> factory)

--- a/Assets/Building/GridPlacer.cs
+++ b/Assets/Building/GridPlacer.cs
@@ -355,6 +355,8 @@ namespace TavernSim.Building
             AddChair(table, root.transform, tableId, 0, new Vector3(0f, 0f, 0.9f));
             AddChair(table, root.transform, tableId, 1, new Vector3(0f, 0f, -0.9f));
 
+            AttachPresenter(root, table);
+
             return table;
         }
 
@@ -366,6 +368,8 @@ namespace TavernSim.Building
             CreateTableTop(root.transform, new Vector3(2.6f, 0.1f, 1.4f));
             AddBench(table, root.transform, tableId, 0, new Vector3(0f, 0f, 1.15f));
             AddBench(table, root.transform, tableId, 2, new Vector3(0f, 0f, -1.15f));
+
+            AttachPresenter(root, table);
 
             return table;
         }
@@ -468,6 +472,22 @@ namespace TavernSim.Building
             back.transform.SetParent(bench.transform, false);
             back.transform.localPosition = new Vector3(0f, 0.6f, -0.3f);
             back.transform.localScale = new Vector3(BenchLength, 1.2f, 0.2f);
+        }
+
+        private static void AttachPresenter(GameObject root, Table table)
+        {
+            if (root == null || table == null)
+            {
+                return;
+            }
+
+            var presenter = root.GetComponent<TablePresenter>();
+            if (presenter == null)
+            {
+                presenter = root.AddComponent<TablePresenter>();
+            }
+
+            presenter.Initialize(table);
         }
     }
 }

--- a/Assets/Building/TablePresenter.cs
+++ b/Assets/Building/TablePresenter.cs
@@ -1,0 +1,71 @@
+using UnityEngine;
+using TavernSim.Core;
+using TavernSim.Simulation.Models;
+
+namespace TavernSim.Building
+{
+    /// <summary>
+    /// Exposes table data through the selection system so the HUD can display details.
+    /// </summary>
+    public sealed class TablePresenter : MonoBehaviour, ISelectable
+    {
+        private Table _table;
+
+        public string DisplayName => _table != null ? $"Mesa {_table.Id}" : gameObject.name;
+
+        public Transform Transform => transform;
+
+        public Table Table => _table;
+
+        public int TableId => _table != null ? _table.Id : -1;
+
+        public int SeatCount
+        {
+            get
+            {
+                if (_table == null)
+                {
+                    return 0;
+                }
+
+                var seats = _table.Seats;
+                return seats != null ? seats.Count : 0;
+            }
+        }
+
+        public int OccupiedSeats
+        {
+            get
+            {
+                if (_table == null)
+                {
+                    return 0;
+                }
+
+                var seats = _table.Seats;
+                if (seats == null)
+                {
+                    return 0;
+                }
+
+                var occupied = 0;
+                for (int i = 0; i < seats.Count; i++)
+                {
+                    if (seats[i].Occupied)
+                    {
+                        occupied++;
+                    }
+                }
+
+                return occupied;
+            }
+        }
+
+        public float Dirtiness => _table != null ? _table.Dirtiness : 0f;
+
+        public void Initialize(Table table)
+        {
+            _table = table;
+        }
+    }
+}

--- a/Assets/Simulation/Systems/AgentSystem.cs
+++ b/Assets/Simulation/Systems/AgentSystem.cs
@@ -50,7 +50,7 @@ namespace TavernSim.Simulation.Systems
         public event Action<int> ActiveCustomerCountChanged;
         public int ActiveCustomerCount => _customers.Count;
         public event Action<Customer> CustomerReleased;
-        public event Action<Customer> CustomerLeftAngry;
+        public event Action<Customer, string> CustomerLeftAngry;
 
         public AgentSystem(TableRegistry tableRegistry, OrderSystem orderSystem, EconomySystem economySystem, CleaningSystem cleaningSystem, Catalog catalog)
         {
@@ -92,6 +92,16 @@ namespace TavernSim.Simulation.Systems
         public void SetReputationSystem(ReputationSystem reputationSystem)
         {
             _reputationSystem = reputationSystem;
+        }
+
+        public bool HasAvailableSeating()
+        {
+            return _tableRegistry != null && _tableRegistry.HasAnySeat();
+        }
+
+        public bool HasActiveWaiter()
+        {
+            return _waiters.Count > 0;
         }
 
         public void Initialize(Sim simulation)
@@ -324,7 +334,7 @@ namespace TavernSim.Simulation.Systems
                         data.SearchTimer = 0f;
                         data.BlockReason = "Sem mesas disponíveis";
                         PublishCustomerAngry(data, data.BlockReason, -1);
-                        CustomerLeftAngry?.Invoke(data.Agent);
+                        CustomerLeftAngry?.Invoke(data.Agent, data.BlockReason);
                         _reputationSystem?.Add(-2);
                         return;
                     }
@@ -790,7 +800,7 @@ namespace TavernSim.Simulation.Systems
             data.PendingRecipe = null;
             data.CurrentRecipe = null;
             PublishCustomerAngry(data, reason, tableId);
-            CustomerLeftAngry?.Invoke(data.Agent);
+            CustomerLeftAngry?.Invoke(data.Agent, reason);
             data.BlockReason = string.Empty;
             _reputationSystem?.Add(-2);
 

--- a/Assets/Simulation/Systems/ReputationSystem.cs
+++ b/Assets/Simulation/Systems/ReputationSystem.cs
@@ -58,5 +58,15 @@ namespace TavernSim.Simulation.Systems
 
             Set(_reputation + delta);
         }
+
+        public void Remove(int delta)
+        {
+            if (delta <= 0)
+            {
+                return;
+            }
+
+            Set(_reputation - delta);
+        }
     }
 }

--- a/Assets/Simulation/Systems/ReputationSystem.cs
+++ b/Assets/Simulation/Systems/ReputationSystem.cs
@@ -1,6 +1,7 @@
 using System;
 using UnityEngine;
 using TavernSim.Core.Simulation;
+using Sim = TavernSim.Core.Simulation.Simulation;
 
 namespace TavernSim.Simulation.Systems
 {
@@ -20,7 +21,7 @@ namespace TavernSim.Simulation.Systems
 
         public int Reputation => _reputation;
 
-        public void Initialize(Simulation simulation)
+        public void Initialize(Sim simulation)
         {
         }
 

--- a/Assets/Simulation/Systems/ReputationSystem.cs
+++ b/Assets/Simulation/Systems/ReputationSystem.cs
@@ -1,0 +1,61 @@
+using System;
+using UnityEngine;
+using TavernSim.Core.Simulation;
+
+namespace TavernSim.Simulation.Systems
+{
+    /// <summary>
+    /// Tracks tavern reputation and exposes change notifications for the HUD.
+    /// </summary>
+    public sealed class ReputationSystem : ISimSystem
+    {
+        private int _reputation;
+
+        public ReputationSystem(int initialReputation = 50)
+        {
+            _reputation = Mathf.Clamp(initialReputation, 0, 100);
+        }
+
+        public event Action<int> ReputationChanged;
+
+        public int Reputation => _reputation;
+
+        public void Initialize(Simulation simulation)
+        {
+        }
+
+        public void Tick(float deltaTime)
+        {
+        }
+
+        public void LateTick(float deltaTime)
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public void Set(int value)
+        {
+            value = Mathf.Clamp(value, 0, 100);
+            if (value == _reputation)
+            {
+                return;
+            }
+
+            _reputation = value;
+            ReputationChanged?.Invoke(_reputation);
+        }
+
+        public void Add(int delta)
+        {
+            if (delta == 0)
+            {
+                return;
+            }
+
+            Set(_reputation + delta);
+        }
+    }
+}

--- a/Assets/Simulation/Systems/TableRegistry.cs
+++ b/Assets/Simulation/Systems/TableRegistry.cs
@@ -84,6 +84,19 @@ namespace TavernSim.Simulation.Systems
             return null;
         }
 
+        public bool HasAnySeat()
+        {
+            for (int i = 0; i < _tables.Count; i++)
+            {
+                if (_tables[i].HasFreeSeat(out _))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public void Dispose()
         {
             _tables.Clear();

--- a/Assets/UI/HUDController.cs
+++ b/Assets/UI/HUDController.cs
@@ -966,6 +966,8 @@ namespace TavernSim.UI
             _reputationLabel.text = $"Reputação: {value}";
         }
 
+        private int _hudPointerDepth;
+
         private void RegisterHudPointerGuards(VisualElement rootElement)
         {
             if (_pointerGuardsRegistered || rootElement == null)
@@ -985,15 +987,13 @@ namespace TavernSim.UI
                 return;
             }
 
-            var targetElement = evt.target as VisualElement;
-            var relatedElement = evt.relatedTarget as VisualElement;
-            if (targetElement != null && relatedElement != null && relatedElement.panel == targetElement.panel)
-            {
-                return;
-            }
+            _hudPointerDepth++;
 
-            _isPointerOverHud = true;
-            UpdatePointerOverHud();
+            if (_hudPointerDepth == 1)
+            {
+                _isPointerOverHud = true;
+                UpdatePointerOverHud();
+            }
         }
 
         private void OnHudPointerLeave(PointerLeaveEvent evt)
@@ -1003,15 +1003,16 @@ namespace TavernSim.UI
                 return;
             }
 
-            var targetElement = evt.target as VisualElement;
-            var relatedElement = evt.relatedTarget as VisualElement;
-            if (targetElement != null && relatedElement != null && relatedElement.panel == targetElement.panel)
+            if (_hudPointerDepth > 0)
             {
-                return;
+                _hudPointerDepth--;
             }
 
-            _isPointerOverHud = false;
-            UpdatePointerOverHud();
+            if (_hudPointerDepth == 0)
+            {
+                _isPointerOverHud = false;
+                UpdatePointerOverHud();
+            }
         }
 
         private void UpdatePointerOverHud()

--- a/Assets/UI/HUDController.cs
+++ b/Assets/UI/HUDController.cs
@@ -108,7 +108,7 @@ namespace TavernSim.UI
             HighlightActiveOption(_gridPlacer != null ? _gridPlacer.ActiveKind : GridPlacer.PlaceableKind.None);
             UpdateSelectionLabel(_selectionService != null ? _selectionService.Current : null);
             UpdateSelectionDetails(_selectionService != null ? _selectionService.Current : null);
-            SetBuildMenuVisible(false);
+            SetBuildMenuVisible(false, true);
 
             if (isActiveAndEnabled)
             {
@@ -303,7 +303,7 @@ namespace TavernSim.UI
             _buildMenu = rootElement.Q<VisualElement>("buildMenu") ?? CreateBuildMenu(layoutRoot);
 
             CreateBuildButtons();
-            SetBuildMenuVisible(false);
+            SetBuildMenuVisible(false, true);
 
             var menuController = GetComponent<MenuController>();
             menuController?.RebuildMenu();
@@ -555,7 +555,7 @@ namespace TavernSim.UI
 
         private void ToggleBuildMenu()
         {
-            SetBuildMenuVisible(!_buildMenuVisible);
+            SetBuildMenuVisible(!_buildMenuVisible, true);
         }
 
         private void OnHireWaiterClicked()
@@ -568,12 +568,28 @@ namespace TavernSim.UI
             HireCookRequested?.Invoke();
         }
 
-        private void SetBuildMenuVisible(bool visible)
+        private void SetBuildMenuVisible(bool visible, bool triggeredByToggle = false)
         {
             _buildMenuVisible = visible;
             if (_buildMenu != null)
             {
                 _buildMenu.style.display = visible ? DisplayStyle.Flex : DisplayStyle.None;
+            }
+
+            if (_gridPlacer != null)
+            {
+                if (visible)
+                {
+                    _gridPlacer.SetBuildMode(true);
+                }
+                else if (triggeredByToggle)
+                {
+                    _gridPlacer.ExitBuildMode();
+                }
+                else if (!_gridPlacer.HasActivePlacement)
+                {
+                    _gridPlacer.SetBuildMode(false);
+                }
             }
         }
 
@@ -614,9 +630,9 @@ namespace TavernSim.UI
 
             if (evt.currentTarget is Button optionButton && optionButton.userData is GridPlacer.PlaceableKind kind)
             {
-                if (_gridPlacer.ActiveKind == kind)
+                if (_gridPlacer.ActiveKind == kind && _gridPlacer.BuildModeActive)
                 {
-                    _gridPlacer.CancelPlacement();
+                    _gridPlacer.ExitBuildMode();
                 }
                 else
                 {

--- a/Assets/UI/HUDController.cs
+++ b/Assets/UI/HUDController.cs
@@ -33,7 +33,6 @@ namespace TavernSim.UI
         private Label _controlsLabel;
         private Label _cashLabel;
         private Label _customerLabel;
-        private Label _selectionLabel;
         private VisualElement _selectionDetailsPanel;
         private Label _selectionDetailsTitle;
         private Label _selectionDetailsBody;
@@ -106,7 +105,6 @@ namespace TavernSim.UI
 
             RefreshBuildOptionLabels();
             HighlightActiveOption(_gridPlacer != null ? _gridPlacer.ActiveKind : GridPlacer.PlaceableKind.None);
-            UpdateSelectionLabel(_selectionService != null ? _selectionService.Current : null);
             UpdateSelectionDetails(_selectionService != null ? _selectionService.Current : null);
             SetBuildMenuVisible(false, true);
 
@@ -286,7 +284,6 @@ namespace TavernSim.UI
             _ordersScroll = rootElement.Q<ScrollView>("ordersScroll") ?? CreateScroll(layoutRoot);
             _saveButton = rootElement.Q<Button>("saveBtn") ?? CreateButton(layoutRoot, "saveBtn", "Save (F5)");
             _loadButton = rootElement.Q<Button>("loadBtn") ?? CreateButton(layoutRoot, "loadBtn", "Load (F9)");
-            _selectionLabel = rootElement.Q<Label>("selectionLabel") ?? CreateLabel(layoutRoot, "selectionLabel", "Selecionado: Nenhum");
             _hireControls = rootElement.Q<VisualElement>("hireControls") ?? CreateHireControls(layoutRoot);
             _hireWaiterButton = rootElement.Q<Button>("hireWaiterBtn") ?? CreateButton(_hireControls, "hireWaiterBtn", "Contratar garçom");
             _hireCookButton = rootElement.Q<Button>("hireCookBtn") ?? CreateButton(_hireControls, "hireCookBtn", "Contratar cozinheiro");
@@ -646,36 +643,25 @@ namespace TavernSim.UI
 
         private void OnSelectionChanged(ISelectable selectable)
         {
-            UpdateSelectionLabel(selectable);
             UpdateSelectionDetails(selectable);
-        }
-
-        private void UpdateSelectionLabel(ISelectable selectable)
-        {
-            if (_selectionLabel == null)
-            {
-                return;
-            }
-
-            _selectionLabel.text = selectable != null
-                ? $"Selecionado: {selectable.DisplayName}"
-                : "Selecionado: Nenhum";
         }
 
         private void UpdateSelectionDetails(ISelectable selectable)
         {
-            if (_selectionDetailsTitle == null || _selectionDetailsBody == null)
+            if (_selectionDetailsPanel == null || _selectionDetailsTitle == null || _selectionDetailsBody == null)
             {
                 return;
             }
 
             if (selectable == null)
             {
-                _selectionDetailsTitle.text = "Sem seleção";
-                _selectionDetailsBody.text = "Clique em um cliente, funcionário ou mesa para ver detalhes.";
+                _selectionDetailsPanel.style.display = DisplayStyle.None;
+                _selectionDetailsTitle.text = string.Empty;
+                _selectionDetailsBody.text = string.Empty;
                 return;
             }
 
+            _selectionDetailsPanel.style.display = DisplayStyle.Flex;
             _selectionDetailsTitle.text = selectable.DisplayName ?? "Selecionado";
             _selectionDetailsBuilder.Clear();
 
@@ -877,6 +863,7 @@ namespace TavernSim.UI
                 _selectionDetailsPanel.style.borderBottomLeftRadius = 8f;
                 _selectionDetailsPanel.style.borderBottomRightRadius = 8f;
                 _selectionDetailsPanel.style.flexDirection = FlexDirection.Column;
+                _selectionDetailsPanel.style.display = DisplayStyle.None;
                 rootElement.Add(_selectionDetailsPanel);
             }
 

--- a/Assets/UI/HUDController.cs
+++ b/Assets/UI/HUDController.cs
@@ -44,6 +44,7 @@ namespace TavernSim.UI
         private VisualElement _hireControls;
         private Button _hireWaiterButton;
         private Button _hireCookButton;
+        private Button _hireBartenderButton;
         private VisualElement _buildMenu;
         private readonly List<Label> _orderEntries = new List<Label>(16);
         private readonly List<Button> _buildOptionButtons = new List<Button>();
@@ -60,6 +61,7 @@ namespace TavernSim.UI
 
         public event Action HireWaiterRequested;
         public event Action HireCookRequested;
+        public event Action HireBartenderRequested;
 
         private static readonly BuildOption[] BuildOptions =
         {
@@ -287,9 +289,12 @@ namespace TavernSim.UI
             _hireControls = rootElement.Q<VisualElement>("hireControls") ?? CreateHireControls(layoutRoot);
             _hireWaiterButton = rootElement.Q<Button>("hireWaiterBtn") ?? CreateButton(_hireControls, "hireWaiterBtn", "Contratar garçom");
             _hireCookButton = rootElement.Q<Button>("hireCookBtn") ?? CreateButton(_hireControls, "hireCookBtn", "Contratar cozinheiro");
+            _hireBartenderButton = rootElement.Q<Button>("hireBartenderBtn") ?? CreateButton(_hireControls, "hireBartenderBtn", "Contratar bartender");
             _hireWaiterButton?.AddToClassList("hud-button");
             _hireCookButton?.AddToClassList("hud-button");
             _hireCookButton?.AddToClassList("stacked");
+            _hireBartenderButton?.AddToClassList("hud-button");
+            _hireBartenderButton?.AddToClassList("stacked");
 
             if (_hireWaiterButton != null)
             {
@@ -357,6 +362,12 @@ namespace TavernSim.UI
                 _hireCookButton.clicked += OnHireCookClicked;
             }
 
+            if (_hireBartenderButton != null)
+            {
+                _hireBartenderButton.clicked -= OnHireBartenderClicked;
+                _hireBartenderButton.clicked += OnHireBartenderClicked;
+            }
+
             if (_selectionService != null)
             {
                 _selectionService.SelectionChanged -= OnSelectionChanged;
@@ -422,6 +433,11 @@ namespace TavernSim.UI
             if (_hireCookButton != null)
             {
                 _hireCookButton.clicked -= OnHireCookClicked;
+            }
+
+            if (_hireBartenderButton != null)
+            {
+                _hireBartenderButton.clicked -= OnHireBartenderClicked;
             }
 
             if (_selectionService != null)
@@ -563,6 +579,11 @@ namespace TavernSim.UI
         private void OnHireCookClicked()
         {
             HireCookRequested?.Invoke();
+        }
+
+        private void OnHireBartenderClicked()
+        {
+            HireBartenderRequested?.Invoke();
         }
 
         private void SetBuildMenuVisible(bool visible, bool triggeredByToggle = false)


### PR DESCRIPTION
## Summary
- keep intent labels facing the active camera and expose current status for HUD consumption
- add a selection details panel plus reputation counter in the HUD backed by a new reputation system
- make tables selectable, release seats when customers leave, and adjust agent logic to update reputation

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68d0a088fcc083339d2142c2a6f2bc5a