### PR TITLE
Add central HUD time control interactions

### DIFF
--- a/Assets/UI/HUD/Components/CentralHUD.uxml
+++ b/Assets/UI/HUD/Components/CentralHUD.uxml
@@ -2,10 +2,10 @@
     <Style src="project://database/Assets/UI/USS/center.uss?fileID=7433441132597879392&amp;guid=5c43e8d21f62e3a4aac3cc48d550e776&amp;type=3#center" />
     <ui:VisualElement name="centralHUD" class="centerHUD" style="background-image: url(&quot;project://database/Assets/UI/Images/center.png?fileID=2800000&amp;guid=93fb208b0ab53f546858d4cde02817c2&amp;type=3#center&quot;); height: 120px; align-items: auto; justify-content: center;">
         <ui:VisualElement name="timeControls" class="timeControls">
-            <ui:VisualElement name="pauseBtn" class="timeButton" style="background-image: url(&quot;project://database/Assets/UI/Icons/HUD/pause-button.png?fileID=2800000&amp;guid=2688b1657b3b1384f9343df330eb0c1d&amp;type=3#pause-button&quot;);" />
-            <ui:VisualElement name="step1Btn" class="timeButton" style="background-image: url(&quot;project://database/Assets/UI/Icons/HUD/play-button.png?fileID=2800000&amp;guid=9ee744a3e7dee1441bf08d03a1169d68&amp;type=3#play-button&quot;);" />
-            <ui:VisualElement name="step2Btn" class="timeButton" style="background-image: url(&quot;project://database/Assets/UI/Icons/HUD/faststep.png?fileID=2800000&amp;guid=9ac0c2708f4c8f84cafd7804a647f56a&amp;type=3#faststep&quot;);" />
-            <ui:VisualElement name="step3Btn" class="timeButton" style="background-image: url(&quot;project://database/Assets/UI/Icons/HUD/step.png?fileID=2800000&amp;guid=43043f2bbbcbb2b4a89ea2de76bbad98&amp;type=3#step&quot;);" />
+            <ui:Button name="pauseBtn" class="timeButton" text="" style="background-image: url(&quot;project://database/Assets/UI/Icons/HUD/pause-button.png?fileID=2800000&amp;guid=2688b1657b3b1384f9343df330eb0c1d&amp;type=3#pause-button&quot;);" />
+            <ui:Button name="step1Btn" class="timeButton" text="" style="background-image: url(&quot;project://database/Assets/UI/Icons/HUD/play-button.png?fileID=2800000&amp;guid=9ee744a3e7dee1441bf08d03a1169d68&amp;type=3#play-button&quot;);" />
+            <ui:Button name="step2Btn" class="timeButton" text="" style="background-image: url(&quot;project://database/Assets/UI/Icons/HUD/faststep.png?fileID=2800000&amp;guid=9ac0c2708f4c8f84cafd7804a647f56a&amp;type=3#faststep&quot;);" />
+            <ui:Button name="step3Btn" class="timeButton" text="" style="background-image: url(&quot;project://database/Assets/UI/Icons/HUD/step.png?fileID=2800000&amp;guid=43043f2bbbcbb2b4a89ea2de76bbad98&amp;type=3#step&quot;);" />
         </ui:VisualElement>
         <ui:Label name="currentTimeLabel" text="Sun. 10:21 AM" class="clock" />
     </ui:VisualElement>

--- a/Assets/UI/HUD/Controllers/CentralHudController.cs
+++ b/Assets/UI/HUD/Controllers/CentralHudController.cs
@@ -1,0 +1,147 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UIElements;
+using TavernSim.Simulation.Systems;
+
+namespace TavernSim.UI
+{
+    /// <summary>
+    /// Controller responsável pelos controles centrais de tempo do HUD.
+    /// Gerencia botões de velocidade e sincroniza o relógio exibido.
+    /// </summary>
+    public class CentralHudController
+    {
+        private const string ActiveClass = "timeButton-active";
+
+        private readonly VisualElement _root;
+        private readonly GameClockSystem _clock;
+
+        private Label _currentTimeLabel;
+        private Button _pauseButton;
+        private Button _step1Button;
+        private Button _step2Button;
+        private Button _step3Button;
+
+        private readonly List<Button> _timeButtons = new List<Button>();
+
+        public CentralHudController(VisualElement root, GameClockSystem clock)
+        {
+            _root = root;
+            _clock = clock;
+        }
+
+        public void Initialize()
+        {
+            var central = _root?.Q("centralHUD") ?? _root;
+            if (central == null)
+            {
+                return;
+            }
+
+            _currentTimeLabel = central.Q<Label>("currentTimeLabel");
+            _pauseButton = central.Q<Button>("pauseBtn");
+            _step1Button = central.Q<Button>("step1Btn");
+            _step2Button = central.Q<Button>("step2Btn");
+            _step3Button = central.Q<Button>("step3Btn");
+
+            CacheButtons();
+
+            _pauseButton?.RegisterCallback<ClickEvent>(_ => OnTimeButtonClicked(0f));
+            _step1Button?.RegisterCallback<ClickEvent>(_ => OnTimeButtonClicked(1f));
+            _step2Button?.RegisterCallback<ClickEvent>(_ => OnTimeButtonClicked(2f));
+            _step3Button?.RegisterCallback<ClickEvent>(_ => OnTimeButtonClicked(3f));
+
+            if (_clock != null)
+            {
+                _clock.TimeChanged -= OnTimeChanged;
+                _clock.TimeChanged += OnTimeChanged;
+                UpdateActiveButton(_clock.CurrentScale);
+                UpdateTimeLabel(_clock.Snapshot.ToString());
+            }
+            else
+            {
+                UpdateActiveButton(1f);
+                UpdateTimeLabel("Dia 1 – 08:00");
+            }
+        }
+
+        private void CacheButtons()
+        {
+            _timeButtons.Clear();
+
+            if (_pauseButton != null)
+            {
+                _timeButtons.Add(_pauseButton);
+            }
+
+            if (_step1Button != null)
+            {
+                _timeButtons.Add(_step1Button);
+            }
+
+            if (_step2Button != null)
+            {
+                _timeButtons.Add(_step2Button);
+            }
+
+            if (_step3Button != null)
+            {
+                _timeButtons.Add(_step3Button);
+            }
+        }
+
+        private void OnTimeButtonClicked(float scale)
+        {
+            _clock?.SetScale(scale);
+            UpdateActiveButton(scale);
+        }
+
+        private void OnTimeChanged(GameClockSystem.GameClockSnapshot snapshot)
+        {
+            UpdateTimeLabel(snapshot.ToString());
+            if (_clock != null)
+            {
+                UpdateActiveButton(_clock.CurrentScale);
+            }
+        }
+
+        private void UpdateTimeLabel(string text)
+        {
+            if (_currentTimeLabel == null)
+            {
+                return;
+            }
+
+            _currentTimeLabel.text = text;
+        }
+
+        private void UpdateActiveButton(float scale)
+        {
+            foreach (var button in _timeButtons)
+            {
+                button?.RemoveFromClassList(ActiveClass);
+            }
+
+            Button target = null;
+
+            if (_pauseButton != null && (Mathf.Approximately(scale, 0f) || scale <= 0f))
+            {
+                target = _pauseButton;
+            }
+            else if (_step1Button != null && scale > 0f && scale < 1.5f)
+            {
+                target = _step1Button;
+            }
+            else if (_step2Button != null && scale >= 1.5f && scale < 2.5f)
+            {
+                target = _step2Button;
+            }
+            else if (_step3Button != null)
+            {
+                target = _step3Button;
+            }
+
+            target?.AddToClassList(ActiveClass);
+        }
+    }
+}

--- a/Assets/UI/HUD/Controllers/CentralHudController.cs
+++ b/Assets/UI/HUD/Controllers/CentralHudController.cs
@@ -50,10 +50,10 @@ namespace TavernSim.UI
 
             CacheButtons();
 
-            _pauseButton?.RegisterCallback<ClickEvent>(_ => OnTimeButtonClicked(0f));
-            _step1Button?.RegisterCallback<ClickEvent>(_ => OnTimeButtonClicked(1f));
-            _step2Button?.RegisterCallback<ClickEvent>(_ => OnTimeButtonClicked(2f));
-            _step3Button?.RegisterCallback<ClickEvent>(_ => OnTimeButtonClicked(3f));
+            _pauseButton?.RegisterCallback<ClickEvent>(evt => OnTimeButtonClicked(0f, evt.currentTarget as VisualElement));
+            _step1Button?.RegisterCallback<ClickEvent>(evt => OnTimeButtonClicked(1f, evt.currentTarget as VisualElement));
+            _step2Button?.RegisterCallback<ClickEvent>(evt => OnTimeButtonClicked(2f, evt.currentTarget as VisualElement));
+            _step3Button?.RegisterCallback<ClickEvent>(evt => OnTimeButtonClicked(3f, evt.currentTarget as VisualElement));
 
             if (_clock != null)
             {
@@ -102,8 +102,18 @@ namespace TavernSim.UI
             }
         }
 
-        private void OnTimeButtonClicked(float scale)
+        private void OnTimeButtonClicked(float scale, VisualElement source)
         {
+            var buttonName = source?.name;
+            if (!string.IsNullOrEmpty(buttonName))
+            {
+                Debug.Log($"[CentralHudController] Botão '{buttonName}' clicado com escala {scale}.");
+            }
+            else
+            {
+                Debug.Log($"[CentralHudController] Controle de tempo clicado com escala {scale}.");
+            }
+
             _clock?.SetScale(scale);
             _lastKnownScale = scale;
             UpdateActiveButton(scale);

--- a/Assets/UI/HUD/Controllers/HUDController.cs
+++ b/Assets/UI/HUD/Controllers/HUDController.cs
@@ -47,6 +47,7 @@ namespace TavernSim.UI
         private BuildMenuController _buildMenuController;
         private SelectionPopupController _selectionPopupController;
         private HudToastController _toastController;
+        private CentralHudController _centralHudController;
         
         // Sistemas para compatibilidade
         private SaveService _saveService;
@@ -82,6 +83,7 @@ namespace TavernSim.UI
             // Buscar elementos dos templates importados
             var topBar = _root.Q("topBar");
             var bottomBar = _root.Q("bottomBar");
+            var centralHud = _root.Q("centralHUD");
             var sidePanel = _root.Q("sidePanel");
             var staffPanel = _root.Q("staffPanel");
             var buildMenu = _root.Q("buildMenu");
@@ -90,6 +92,7 @@ namespace TavernSim.UI
             // Criar controllers especializados
             _topBarController = new TopBarController(topBar, economySystem, reputationSystem, clockSystem, weatherService);
             _bottomBarController = new BottomBarController(bottomBar, economySystem, clockSystem, weatherService);
+            _centralHudController = new CentralHudController(centralHud, clockSystem ?? _clockSystem);
             _sidePanelController = new SidePanelController(sidePanel, economySystem, orderSystem, reputationSystem);
             _staffPanelController = new StaffPanelController(staffPanel);
             _buildMenuController = new BuildMenuController(buildMenu, buildCatalog, gridPlacer);
@@ -106,6 +109,7 @@ namespace TavernSim.UI
         {
             _topBarController?.Initialize();
             _bottomBarController?.Initialize();
+            _centralHudController?.Initialize();
             _sidePanelController?.Initialize();
             _staffPanelController?.Initialize();
             _buildMenuController?.Initialize();

--- a/Assets/UI/HUD/Controllers/HUDController.cs
+++ b/Assets/UI/HUD/Controllers/HUDController.cs
@@ -303,9 +303,10 @@ namespace TavernSim.UI
             _buildCatalog = buildCatalog;
         }
         
-        public void BindClock(GameClockSystem clockSystem) 
+        public void BindClock(GameClockSystem clockSystem)
         {
             _clockSystem = clockSystem;
+            _centralHudController?.BindClock(clockSystem);
         }
         
         public void BindWeather(IWeatherService weatherService) 

--- a/Assets/UI/HUD/Controllers/HUDController.cs
+++ b/Assets/UI/HUD/Controllers/HUDController.cs
@@ -76,6 +76,7 @@ namespace TavernSim.UI
         private void OnDisable()
         {
             UnhookEvents();
+            _centralHudController?.Dispose();
         }
 
         private void SetupControllers()

--- a/Assets/UI/HUD/Controllers/HUDController.cs
+++ b/Assets/UI/HUD/Controllers/HUDController.cs
@@ -94,7 +94,14 @@ namespace TavernSim.UI
             _topBarController = new TopBarController(topBar, economySystem, reputationSystem, clockSystem, weatherService);
             _bottomBarController = new BottomBarController(bottomBar, economySystem, clockSystem, weatherService);
             _centralHudController = new CentralHudController(centralHud, clockSystem ?? _clockSystem);
-            _sidePanelController = new SidePanelController(sidePanel, economySystem, orderSystem, reputationSystem);
+            if (sidePanel != null)
+            {
+                _sidePanelController = new SidePanelController(sidePanel, economySystem, orderSystem, reputationSystem);
+            }
+            else
+            {
+                Debug.LogWarning("HUDController: elemento 'sidePanel' não encontrado. Controlador do painel lateral não será inicializado.");
+            }
             _staffPanelController = new StaffPanelController(staffPanel);
             _buildMenuController = new BuildMenuController(buildMenu, buildCatalog, gridPlacer);
             _selectionPopupController = new SelectionPopupController(selectionPopup);

--- a/Assets/UI/HUD/Controllers/SidePanelController.cs
+++ b/Assets/UI/HUD/Controllers/SidePanelController.cs
@@ -46,6 +46,12 @@ namespace TavernSim.UI
 
         public void Initialize()
         {
+            if (_root == null)
+            {
+                Debug.LogWarning("SidePanelController: raiz do painel lateral não encontrada. Inicialização ignorada.");
+                return;
+            }
+
             SetupUI();
             HookEvents();
             Hide(); // Começar oculto
@@ -53,6 +59,11 @@ namespace TavernSim.UI
 
         private void SetupUI()
         {
+            if (_root == null)
+            {
+                return;
+            }
+
             _sidePanel = _root.Q("sidePanel");
             _closeButton = _root.Q<Button>("panelCloseBtn");
             _toggleButton = _root.Q<Button>("sidePanelToggleBtn");

--- a/Assets/UI/HUD/HUD.uxml
+++ b/Assets/UI/HUD/HUD.uxml
@@ -4,13 +4,13 @@
     <ui:Template name="CentralHUD" src="project://database/Assets/UI/HUD/Components/CentralHUD.uxml?fileID=9197481963319205126&amp;guid=98b33f0173bc8ae4a8eff437e1f850a6&amp;type=3#CentralHUD" />
     <Style src="project://database/Assets/UI/HUD/Styles/HUD.uss?fileID=7433441132597879392&amp;guid=62dcbfcf8caabc14a81ecc993a592c77&amp;type=3#HUD" />
     <ui:VisualElement name="hudRoot" class="hud-root">
-        <ui:VisualElement class="hud-top">
+        <ui:VisualElement class="hud-layer hud-layer__top">
             <ui:Instance template="TopBar" name="TopBar" />
         </ui:VisualElement>
-        <ui:VisualElement class="hud-bottom-left">
+        <ui:VisualElement class="hud-layer hud-layer__bottom-left">
             <ui:Instance template="BottomBar" name="BottomBar" />
         </ui:VisualElement>
-        <ui:VisualElement class="center-hud-wrapper">
+        <ui:VisualElement class="hud-layer hud-layer__center">
             <ui:Instance template="CentralHUD" name="CentralHUD" />
         </ui:VisualElement>
     </ui:VisualElement>

--- a/Assets/UI/HUD/HUD.uxml
+++ b/Assets/UI/HUD/HUD.uxml
@@ -3,9 +3,15 @@
     <ui:Template name="BottomBar" src="project://database/Assets/UI/HUD/Components/BottomBar.uxml?fileID=9197481963319205126&amp;guid=f0fd9a3f7cc263e44a9216f2ff1e39d3&amp;type=3#BottomBar" />
     <ui:Template name="CentralHUD" src="project://database/Assets/UI/HUD/Components/CentralHUD.uxml?fileID=9197481963319205126&amp;guid=98b33f0173bc8ae4a8eff437e1f850a6&amp;type=3#CentralHUD" />
     <Style src="project://database/Assets/UI/HUD/Styles/HUD.uss?fileID=7433441132597879392&amp;guid=62dcbfcf8caabc14a81ecc993a592c77&amp;type=3#HUD" />
-    <ui:VisualElement name="hudRoot" class="hud-root" style="position: absolute; bottom: 0; top: 0; right: -1px; left: 1px;">
-        <ui:Instance template="TopBar" name="TopBar" />
-        <ui:Instance template="BottomBar" name="BottomBar" style="position: absolute; left: auto; bottom: 1px; height: -1px; width: 339px;" />
-        <ui:Instance template="CentralHUD" name="CentralHUD" style="position: absolute; top: auto; left: 50%; bottom: -40px; right: 50%; align-self: center; align-items: center;" />
+    <ui:VisualElement name="hudRoot" class="hud-root">
+        <ui:VisualElement class="hud-top">
+            <ui:Instance template="TopBar" name="TopBar" />
+        </ui:VisualElement>
+        <ui:VisualElement class="hud-bottom-left">
+            <ui:Instance template="BottomBar" name="BottomBar" />
+        </ui:VisualElement>
+        <ui:VisualElement class="center-hud-wrapper">
+            <ui:Instance template="CentralHUD" name="CentralHUD" />
+        </ui:VisualElement>
     </ui:VisualElement>
 </ui:UXML>

--- a/Assets/UI/HUD/Styles/BottomBar.uss
+++ b/Assets/UI/HUD/Styles/BottomBar.uss
@@ -1,7 +1,7 @@
 /* Barra inferior única */
 .hud-bottom {
-    position: absolute;
-    bottom: 0; left: 0; right: 0;
+    position: relative;
+    width: 100%;
     height: 38px; /* altura conforme seu mock */
     background-color: rgba(0, 0, 0, 0.85);
     border-top: 2px solid #4a4a4a;

--- a/Assets/UI/HUD/Styles/HUD.uss
+++ b/Assets/UI/HUD/Styles/HUD.uss
@@ -17,7 +17,11 @@
     position: absolute;
     bottom: 72px;        /* um pouco acima do bottom */
     left: 50%;
-    transform: translateX(-50%);
+    transform: translate(-50%, 0) scale(1.2);
+    transform-origin: center bottom;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 /* canto inferior esquerdo */

--- a/Assets/UI/HUD/Styles/HUD.uss
+++ b/Assets/UI/HUD/Styles/HUD.uss
@@ -1,45 +1,50 @@
 /* HUD root ocupa tela inteira */
 .hud-root {
     position: absolute;
-    top: 0; left: 0; right: 0; bottom: 0;
-    flex-direction: column; /* opcional */
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}
+
+.hud-layer {
+    position: absolute;
+    display: flex;
 }
 
 /* barra superior ocupa toda a largura no topo */
-.hud-top {
-    position: absolute;
+.hud-layer__top {
     top: 0;
     left: 0;
     right: 0;
     padding: 16px 24px 0 24px;
-    display: flex;
     justify-content: center;
+    align-items: flex-start;
 }
 
-.hud-top > * {
+.hud-layer__top > * {
     width: 100%;
 }
 
 /* centro embaixo (centralizado horizontalmente) */
-.center-hud-wrapper {
-    position: absolute;
+.hud-layer__center {
     bottom: 56px;
     left: 50%;
-    transform: translate(-50%, 0) scale(1.2);
+    transform: translate(-50%, 0) scale(1.25);
     transform-origin: center bottom;
-    display: flex;
     justify-content: center;
     align-items: flex-end;
 }
 
 /* canto inferior esquerdo com largura fixa */
-.hud-bottom-left {
-    position: absolute;
-    bottom: 24px;
-    left: 24px;
+.hud-layer__bottom-left {
+    bottom: 32px;
+    left: 32px;
     width: 200px;
+    justify-content: flex-start;
+    align-items: stretch;
 }
 
-.hud-bottom-left > * {
+.hud-layer__bottom-left > * {
     width: 100%;
 }

--- a/Assets/UI/HUD/Styles/HUD.uss
+++ b/Assets/UI/HUD/Styles/HUD.uss
@@ -5,28 +5,41 @@
     flex-direction: column; /* opcional */
 }
 
-/* topo à direita */
+/* barra superior ocupa toda a largura no topo */
 .hud-top {
     position: absolute;
-    top: 16px;
-    right: 16px;
+    top: 0;
+    left: 0;
+    right: 0;
+    padding: 16px 24px 0 24px;
+    display: flex;
+    justify-content: center;
 }
 
-/* centro embaixo */
+.hud-top > * {
+    width: 100%;
+}
+
+/* centro embaixo (centralizado horizontalmente) */
 .center-hud-wrapper {
     position: absolute;
-    bottom: 72px;        /* um pouco acima do bottom */
+    bottom: 56px;
     left: 50%;
     transform: translate(-50%, 0) scale(1.2);
     transform-origin: center bottom;
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: flex-end;
 }
 
-/* canto inferior esquerdo */
+/* canto inferior esquerdo com largura fixa */
 .hud-bottom-left {
     position: absolute;
-    bottom: 16px;
-    left: 16px;
+    bottom: 24px;
+    left: 24px;
+    width: 200px;
+}
+
+.hud-bottom-left > * {
+    width: 100%;
 }

--- a/Assets/UI/HUD/Styles/TopBar.uss
+++ b/Assets/UI/HUD/Styles/TopBar.uss
@@ -1,9 +1,7 @@
 /* Container da TopBar */
 .hud-top {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
+    position: relative;
+    width: 100%;
     height: 60px;
     background-color: rgba(0, 0, 0, 0.8);
     border-bottom: 2px solid #4a4a4a;

--- a/Assets/UI/HUD/SystemStubs.cs
+++ b/Assets/UI/HUD/SystemStubs.cs
@@ -14,19 +14,38 @@ namespace TavernSim.UI.SystemStubs
     public static class SystemAPIStubs
     {
         // GameClockSystem stubs
-        public static void Pause(this GameClockSystem clock) 
+        public static void Pause(this GameClockSystem clock)
         {
-            Debug.Log("GameClockSystem.Pause() - stub implementation");
+            if (clock != null)
+            {
+                clock.SetScale(0f);
+            }
+            else
+            {
+                Debug.Log("GameClockSystem.Pause() - stub implementation");
+            }
         }
-        
-        public static void SetSpeed(this GameClockSystem clock, float speed) 
+
+        public static void SetSpeed(this GameClockSystem clock, float speed)
         {
-            Debug.Log($"GameClockSystem.SetSpeed({speed}) - stub implementation");
+            if (clock != null)
+            {
+                clock.SetScale(Mathf.Max(0f, speed));
+            }
+            else
+            {
+                Debug.Log($"GameClockSystem.SetSpeed({speed}) - stub implementation");
+            }
         }
-        
-        public static string GetTimeString(this GameClockSystem clock) 
+
+        public static string GetTimeString(this GameClockSystem clock)
         {
-            return "Dia 1 - 08:00"; // Stub implementation
+            if (clock != null)
+            {
+                return clock.Snapshot.ToString();
+            }
+
+            return "Dia 1 – 08:00"; // Stub implementation
         }
         
         public static GameClockSnapshot GetSnapshot(this GameClockSystem clock) 

--- a/Assets/UI/HUD/SystemStubs.cs
+++ b/Assets/UI/HUD/SystemStubs.cs
@@ -92,6 +92,16 @@ namespace TavernSim.UI.SystemStubs
     {
         public int Day;
         public string Time;
+
+        public override string ToString()
+        {
+            if (string.IsNullOrEmpty(Time))
+            {
+                return $"Dia {Day} – 00:00";
+            }
+
+            return $"Dia {Day} – {Time}";
+        }
     }
     
     public struct WeatherSnapshot

--- a/Assets/UI/USS/center.uss
+++ b/Assets/UI/USS/center.uss
@@ -35,6 +35,10 @@
     opacity: 1.0;
 }
 
+.timeButton-active {
+    -unity-background-image-tint-color: #FFFFFF;
+}
+
 .timeButton:last-child {
     margin-right: 0;
 }


### PR DESCRIPTION
## Summary
- convert the central HUD time controls into buttons and add active-state styling
- introduce a CentralHudController that wires the buttons to the GameClockSystem and updates the label
- integrate the new controller into HUDController and improve clock system stubs to drive the real clock

## Testing
- not run (UI-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e2ecbe1a1c8333a49596d398848e86

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Convert central HUD icons to buttons, add a controller that drives GameClockSystem and active-state UI, integrate into HUD, refactor HUD layout layers, and enhance clock stubs.
> 
> - **UI/UX**:
>   - Convert `centralHUD` time controls from `VisualElement` to `Button` with empty text in `Assets/UI/HUD/Components/CentralHUD.uxml`.
>   - Add active-state styling via `.timeButton-active` in `Assets/UI/USS/center.uss`.
>   - Rework `Assets/UI/HUD/HUD.uxml` to layered structure using `hud-layer` classes; remove inline positioning.
> - **Controllers**:
>   - Add `CentralHudController` to bind time buttons to `GameClockSystem`, update `currentTimeLabel`, and manage active button state.
>   - Integrate `CentralHudController` in `HUDController` (setup, initialize, bind clock, dispose); add null-safe side panel setup and warnings.
>   - Add null-guards in `SidePanelController` initialization.
> - **Styles**:
>   - Update `HUD.uss` to new layered layout (`hud-layer__top`, `__center`, `__bottom-left`).
>   - Make `TopBar.uss` and `BottomBar.uss` containers relative width 100%.
> - **Stubs**:
>   - Improve `SystemStubs` for `GameClockSystem` (use `SetScale`, `CurrentScale`, snapshot formatting).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43c5b0b859e5ee90bdb3512e736192b4fc6c44ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->